### PR TITLE
Enable maven deployments

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -43,6 +43,9 @@ jobs:
           secrets: |
             secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_USR;
             secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_PSW;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
 
       - name: Deploy SNAPSHOT / Release
         id: release
@@ -53,9 +56,9 @@ jobs:
           release-profile: community-action-maven-release
           nexus-usr: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
           nexus-psw: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
-          maven-usr: dummy
-          maven-psw: dummy
-          maven-gpg-passphrase: dummy
+          maven-usr: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          maven-psw: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          maven-gpg-passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attach artifacts to GitHub Release (Release only)

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -41,8 +41,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda-cloud/camunda-cloud-testing ARTIFACTS_USR;
-            secret/data/common/github.com/actions/camunda-cloud/camunda-cloud-testing ARTIFACTS_PSW;
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_USR;
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_PSW;
 
       - name: Deploy SNAPSHOT / Release
         id: release

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Deploy SNAPSHOT / Release
         id: release
-        uses: camunda-community-hub/community-action-maven-release@v1
+        uses: camunda-community-hub/community-action-maven-release@v1.0.12
         with:
           run-tests: true
           release-version: ${{ github.event.release.tag_name }}
@@ -59,6 +59,7 @@ jobs:
           maven-usr: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
           maven-psw: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
           maven-gpg-passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+          maven-url: s01.oss.sonatype.org
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attach artifacts to GitHub Release (Release only)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I've had the infra team rename the location of the secrets in Vault from `camunda-cloud-testing` to `zeebe-process-test`. As a result we modify this location in our CI pipeline.

I've also added the maven central secrets and replaced the dummy values.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
