### PR TITLE
Make RecordStreamSourceImpl threadsafe

### DIFF
--- a/src/test/java/io/camunda/zeebe/process/test/multithread/MultiThreadTest.java
+++ b/src/test/java/io/camunda/zeebe/process/test/multithread/MultiThreadTest.java
@@ -1,0 +1,69 @@
+package io.camunda.zeebe.process.test.multithread;
+
+import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+import static io.camunda.zeebe.process.test.util.Utilities.deployProcess;
+import static io.camunda.zeebe.process.test.util.Utilities.startProcessInstance;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.process.test.RecordStreamSourceStore;
+import io.camunda.zeebe.process.test.extensions.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.testengine.InMemoryEngine;
+import io.camunda.zeebe.process.test.testengine.RecordStreamSource;
+import io.camunda.zeebe.process.test.util.Utilities.ProcessPackStartEndEvent;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@ZeebeProcessTest
+public class MultiThreadTest {
+
+  private InMemoryEngine engine;
+  private ZeebeClient client;
+  private RecordStreamSource recordStreamSource;
+
+  @Test
+  public void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
+    final ExecutorService executorService = Executors.newFixedThreadPool(5);
+
+    final List<Future<Boolean>> futures =
+        executorService.invokeAll(
+            List.of(
+                new ProcessRunner(),
+                new ProcessRunner(),
+                new ProcessRunner(),
+                new ProcessRunner(),
+                new ProcessRunner()));
+
+    for (final Future<Boolean> future : futures) {
+      try {
+        Assertions.assertThat(future.get()).isTrue();
+      } catch (ExecutionException ex) {
+        Assertions.fail("Future completed exceptionally: %s", ExceptionUtils.getStackTrace(ex));
+      }
+    }
+  }
+
+  private class ProcessRunner implements Callable<Boolean> {
+
+    @Override
+    public Boolean call() {
+      RecordStreamSourceStore.init(recordStreamSource);
+
+      deployProcess(client, ProcessPackStartEndEvent.RESOURCE_NAME);
+      final ProcessInstanceEvent instanceEvent =
+          startProcessInstance(engine, client, ProcessPackStartEndEvent.PROCESS_ID);
+      engine.waitForIdleState();
+
+      assertThat(instanceEvent).isCompleted();
+      RecordStreamSourceStore.reset();
+      return true;
+    }
+  }
+}

--- a/src/test/java/io/camunda/zeebe/process/test/util/Utilities.java
+++ b/src/test/java/io/camunda/zeebe/process/test/util/Utilities.java
@@ -62,8 +62,13 @@ public class Utilities {
     public static final String RESOURCE_NAME = "call-activity.bpmn";
     public static final String PROCESS_ID = "call-activity";
     public static final String CALL_ACTIVITY_ID = "callactivity";
-    public static final String CALLED_RESOURCE_NAME = "start-end.bpmn";
-    public static final String CALLED_PROCESS_ID = "start-end";
+    public static final String CALLED_RESOURCE_NAME = ProcessPackStartEndEvent.RESOURCE_NAME;
+    public static final String CALLED_PROCESS_ID = ProcessPackStartEndEvent.PROCESS_ID;
+  }
+
+  public static final class ProcessPackStartEndEvent {
+    public static final String RESOURCE_NAME = "start-end.bpmn";
+    public static final String PROCESS_ID = "start-end";
   }
 
   public static DeploymentEvent deployProcess(final ZeebeClient client, final String process) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I've added a synchronized around the updating of the list of records in the record stream. I've written a test to verify this change solved the issue in #110 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #110 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
