### PR TITLE
Fix thread leaks

### DIFF
--- a/src/main/java/io/camunda/zeebe/process/test/extensions/ZeebeProcessTestExtension.java
+++ b/src/main/java/io/camunda/zeebe/process/test/extensions/ZeebeProcessTestExtension.java
@@ -27,7 +27,14 @@ public class ZeebeProcessTestExtension
     final InMemoryEngine engine = EngineFactory.create();
     final ZeebeClient client = engine.createClient();
     final RecordStreamSource recordStream = engine.getRecordStream();
-    injectFields(extensionContext, engine, client, recordStream);
+
+    try {
+      injectFields(extensionContext, engine, client, recordStream);
+    } catch (final Exception ex) {
+      client.close();
+      engine.stop();
+      throw ex;
+    }
 
     RecordStreamSourceStore.init(recordStream);
     getStore(extensionContext).put(KEY_ZEEBE_CLIENT, client);

--- a/src/test/java/io/camunda/zeebe/process/test/multithread/MultiThreadTest.java
+++ b/src/test/java/io/camunda/zeebe/process/test/multithread/MultiThreadTest.java
@@ -19,6 +19,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @ZeebeProcessTest
@@ -27,11 +29,20 @@ public class MultiThreadTest {
   private InMemoryEngine engine;
   private ZeebeClient client;
   private RecordStreamSource recordStreamSource;
+  private ExecutorService executorService;
+
+  @BeforeEach
+  public void beforeEach() {
+    executorService = Executors.newFixedThreadPool(5);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    executorService.shutdown();
+  }
 
   @Test
   public void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
-    final ExecutorService executorService = Executors.newFixedThreadPool(5);
-
     final List<Future<Boolean>> futures =
         executorService.invokeAll(
             List.of(


### PR DESCRIPTION
## Description

Fixes the thread leaks that occurred in the unit tests.

- In the extension: close the engine and client when injecting the fields raises an exception.
- In the multithread test: Shutdown the executor service upon test completion.

The thread count seems stable around 70-75 threads:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/5787702/148959631-1ecf426b-c1f6-478a-af01-c9dcd9e30ed6.png">


## Related issues

Relates to #122 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
