### PR TITLE
Tests no longer randomly get stuck when waiting for idle state

### DIFF
--- a/src/main/java/io/camunda/zeebe/process/test/testengine/IdleStateMonitor.java
+++ b/src/main/java/io/camunda/zeebe/process/test/testengine/IdleStateMonitor.java
@@ -52,29 +52,27 @@ final class IdleStateMonitor implements LogStorage.CommitListener, StreamProcess
   }
 
   private void checkIdleState() {
-    if (isInIdleState()) {
-      scheduleNotification();
-    } else {
-      cancelNotification();
-    }
-  }
-
-  private void scheduleNotification() {
     synchronized (idleStateNotifier) {
-      idleStateNotifier = createIdleStateNotifier();
-      try {
-        TIMER.schedule(idleStateNotifier, GRACE_PERIOD);
-      } catch (IllegalStateException e) {
-        // thrown - among others - if task was cancelled before it could be scheduled
-        // do nothing in this case
+      if (isInIdleState()) {
+        scheduleNotification();
+      } else {
+        cancelNotification();
       }
     }
   }
 
-  private void cancelNotification() {
-    synchronized (idleStateNotifier) {
-      idleStateNotifier.cancel();
+  private void scheduleNotification() {
+    idleStateNotifier = createIdleStateNotifier();
+    try {
+      TIMER.schedule(idleStateNotifier, GRACE_PERIOD);
+    } catch (IllegalStateException e) {
+      // thrown - among others - if task was cancelled before it could be scheduled
+      // do nothing in this case
     }
+  }
+
+  private void cancelNotification() {
+    idleStateNotifier.cancel();
   }
 
   private boolean isInIdleState() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Tests randomly got stuck when waiting for the engine to be idle. It generally got stuck around the 5000 tests for me locally. With this fix I reached 30.000 tests without getting stuck.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #122 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
