### PR TITLE
Fix workflows for PRs coming from forked repositories

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,20 +41,15 @@ jobs:
           path: target/surefire-reports/
           retention-days: 7
 
-  publish-test-results:
-      name: Publish Unit Test Results
-      runs-on: ubuntu-latest
-      needs: build-and-test
-      if: always()
-
-      steps:
-        - name: Download Artifacts
-          uses: actions/download-artifact@v2
-          with:
-            path: artifacts
-
-        - name: Publish Unit Test Results
-          uses: EnricoMi/publish-unit-test-result-action@v1.26
-          with:
-            files: artifacts/**/*.xml
-
+# We need to upload the event file as an artifact in order to support publishing the results of
+# forked repositories (https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches)
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+          retention-days: 1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
         id: build
         run: mvn -B -U "-Dsurefire.rerunFailingTestsCount=5" clean install
 
-      - name: Archive Test Results on Failure
+      - name: Archive Test Results
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,37 @@
+# Publishing of unit test results has to be a separate workflow in order to support forked PRs
+# See https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
+name: Publish Unit Test Results
+on:
+  workflow_run:
+    workflows: [Build and test]
+    types:
+      - completed
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
PRs from forked repositories would always fail because the workflow is unable to publish the unit test results. This is because the `GITHUB_TOKEN` in these workflows have read-only right.
By putting the publishing of these results in a separate workflow we can work around these access rights. This workflow gets triggered upon completion of the first workflow and downloads the artifacts uploaded in the first workflow. This allows it to publish them without problem.

See: https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #148 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
