### PR TITLE
Modify the workflow to only run 1 job at a time

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Due to the limited resources of the github runners executing the tests for all 3 scenarios could result into timeouts when sending message with the client. Changing this parallelisation to only run 1 job at a time will increase the workflow time to ~10 minutes, but should resolve the flakiness of the message tests.

In the future it would be nice to make client configuration customizable, so we could increase the request timeout for just the problematic tests, while still being able to run our jobs in parallel.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #98 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
