### PR TITLE
Create separate stream writers and don't write synchronously

### DIFF
--- a/src/main/java/io/camunda/zeebe/process/test/testengine/EngineFactory.java
+++ b/src/main/java/io/camunda/zeebe/process/test/testengine/EngineFactory.java
@@ -30,13 +30,14 @@ public class EngineFactory {
 
     final InMemoryLogStorage logStorage = new InMemoryLogStorage();
     final LogStream logStream = createLogStream(logStorage, scheduler, partitionId);
-    final LogStreamRecordWriter streamWriter = logStream.newLogStreamRecordWriter().join();
 
     final SubscriptionCommandSenderFactory subscriptionCommandSenderFactory =
-        new SubscriptionCommandSenderFactory(streamWriter, partitionId);
+        new SubscriptionCommandSenderFactory(
+            logStream.newLogStreamRecordWriter().join(), partitionId);
 
     final GrpcToLogStreamGateway gateway =
-        new GrpcToLogStreamGateway(streamWriter, partitionId, partitionCount, port);
+        new GrpcToLogStreamGateway(
+            logStream.newLogStreamRecordWriter().join(), partitionId, partitionCount, port);
     final Server grpcServer = ServerBuilder.forPort(port).addService(gateway).build();
     final GrpcResponseWriter grpcResponseWriter = new GrpcResponseWriter(gateway);
 

--- a/src/main/java/io/camunda/zeebe/process/test/testengine/GrpcToLogStreamGateway.java
+++ b/src/main/java/io/camunda/zeebe/process/test/testengine/GrpcToLogStreamGateway.java
@@ -94,16 +94,20 @@ public class GrpcToLogStreamGateway extends GatewayGrpc.GatewayImplBase implemen
 
   private void writeCommandWithKey(
       final Long key, final RecordMetadata metadata, final BufferWriter bufferWriter) {
-    writer.reset();
+    synchronized (writer) {
+      writer.reset();
 
-    writer.key(key).metadataWriter(metadata).valueWriter(bufferWriter).tryWrite();
+      writer.key(key).metadataWriter(metadata).valueWriter(bufferWriter).tryWrite();
+    }
   }
 
   private void writeCommandWithoutKey(
       final RecordMetadata metadata, final BufferWriter bufferWriter) {
-    writer.reset();
+    synchronized (writer) {
+      writer.reset();
 
-    writer.keyNull().metadataWriter(metadata).valueWriter(bufferWriter).tryWrite();
+      writer.keyNull().metadataWriter(metadata).valueWriter(bufferWriter).tryWrite();
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Running tests would sometimes result in an IndexOutOfBoundsException upon writing commands. This is most likely caused by multiple threads using the same writer. The first thread would be writing, while the seconds thread resets the writer.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to #158 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
