### PR TITLE
Use ExecutorService for activating jobs

### DIFF
--- a/src/test/java/io/camunda/zeebe/process/test/multithread/WorkerTest.java
+++ b/src/test/java/io/camunda/zeebe/process/test/multithread/WorkerTest.java
@@ -1,0 +1,50 @@
+package io.camunda.zeebe.process.test.multithread;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.process.test.extensions.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.testengine.InMemoryEngine;
+import io.camunda.zeebe.process.test.util.Utilities;
+import io.camunda.zeebe.process.test.util.Utilities.ProcessPackLoopingServiceTask;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@ZeebeProcessTest
+public class WorkerTest {
+
+  private ZeebeClient client;
+  private InMemoryEngine engine;
+
+  @Test
+  public void testJobsCanBeProcessedAsynchronouslyByWorker() throws InterruptedException {
+    // given
+    client
+        .newWorker()
+        .jobType(ProcessPackLoopingServiceTask.JOB_TYPE)
+        .handler(
+            (client, job) -> {
+              client.newCompleteCommand(job.getKey()).send();
+            })
+        .open();
+
+    Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
+    final Map<String, Object> variables =
+        Collections.singletonMap(ProcessPackLoopingServiceTask.TOTAL_LOOPS, 3);
+
+    // when
+    final ProcessInstanceEvent instanceEvent =
+        Utilities.startProcessInstance(
+            engine, client, ProcessPackLoopingServiceTask.PROCESS_ID, variables);
+
+    // then
+    BpmnAssert.assertThat(instanceEvent).isStarted();
+    // TODO: Idle state monitor does not work in this case.
+    //  Might be fixed when switching to the zeebe built-in idle state monitor
+    Thread.sleep(1000);
+    BpmnAssert.assertThat(instanceEvent)
+        .hasPassedElement(ProcessPackLoopingServiceTask.ELEMENT_ID, 3)
+        .isCompleted();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Activating jobs did not make use of the single threaded executor. This caused multiple threads to write at the same time, causing conflicts.

With this fix the synchronized is no longer necessary.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #158

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
