### PR TITLE
fix: builds with JDK16 and higher

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,5 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ describes:
 
 ## Starting on an issue
 
+Please make sure you are using JDK 11 or higher. Lower versions will not build, as the checkstyle we
+use does not support them.
+
 To work on an issue, follow the following steps:
 
 1. Check that a [GitHub issue][issues] exists for the task you want to work on. If this is not the


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The google java format plugin is incompatible with JDK16+. To fix this we need to set these JVM flags. These flags became available after JDK8. This means that with this fix build will fail on JDK8. Therefore, I've updated the contribution guide to specify contributors have to use JDK11+

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #121

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [x] The documentation is updated
