### PR TITLE
Add assertion entry point for ProcessInstanceResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ ProcessInstanceEvent event = client.newCreateInstanceCommand()
 ProcessInstanceAssert assertions = BpmnAssert.assertThat(event);
 ```
 
+```java
+ProcessInstanceResult event = client.newCreateInstanceCommand()
+  .bpmnProcessId("<processId>")
+  .latestVersion()
+  .withResult()
+  .send()
+  .join();
+  ProcessInstanceAssert assertions = BpmnAssert.assertThat(event);
+```
+
 Started by a timer:
 ```java
 Optional<InspectedProcessInstance> firstProcessInstance = InspectionUtility.findProcessEvents()

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
@@ -3,6 +3,7 @@ package io.camunda.zeebe.process.test.assertions;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
@@ -32,6 +33,11 @@ public abstract class BpmnAssert {
   public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent instanceEvent) {
     return new ProcessInstanceAssert(
         instanceEvent.getProcessInstanceKey(), getRecordStreamSource());
+  }
+
+  public static ProcessInstanceAssert assertThat(final ProcessInstanceResult instanceResult) {
+    return new ProcessInstanceAssert(instanceResult.getProcessInstanceKey(),
+        getRecordStreamSource());
   }
 
   public static ProcessInstanceAssert assertThat(

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
@@ -1,0 +1,107 @@
+package io.camunda.zeebe.process.test.assertions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BpmnAssertTest {
+
+  @BeforeEach
+  void beforeEach() {
+    BpmnAssert.initRecordStream(mock(RecordStreamSource.class));
+  }
+
+  @AfterEach
+  void afterEach() {
+    BpmnAssert.resetRecordStream();
+  }
+
+  @Test
+  @DisplayName("Should return ProcessInstanceAssert for ProcessInstanceEvent")
+  void testAssertThatProcessInstanceEventReturnsProcessInstanceAssert() {
+    // given
+    ProcessInstanceEvent event = mock(ProcessInstanceEvent.class);
+
+    // when
+    ProcessInstanceAssert assertions = BpmnAssert.assertThat(event);
+
+    //then
+    assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
+  }
+
+  @Test
+  @DisplayName("Should return ProcessInstanceAssert for ProcessInstanceResult")
+  void testAssertThatProcessInstanceResultReturnsProcessInstanceAssert() {
+    // given
+    ProcessInstanceResult result = mock(ProcessInstanceResult.class);
+
+    // when
+    ProcessInstanceAssert assertions = BpmnAssert.assertThat(result);
+
+    //then
+    assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
+  }
+
+  @Test
+  @DisplayName("Should return ProcessInstanceAssert for InspectedProcessInstance")
+  void testAssertThatInspectedProcessInstanceReturnsProcessInstanceAssert() {
+    // given
+    InspectedProcessInstance inspected = mock(InspectedProcessInstance.class);
+
+    // when
+    ProcessInstanceAssert assertions = BpmnAssert.assertThat(inspected);
+
+    //then
+    assertThat(assertions).isInstanceOf(ProcessInstanceAssert.class);
+  }
+
+  @Test
+  @DisplayName("Should return JobAssert for ActivatedJob")
+  void testAssertThatActivatedJobReturnsJobAssert() {
+    // given
+    ActivatedJob job = mock(ActivatedJob.class);
+
+    // when
+    JobAssert assertions = BpmnAssert.assertThat(job);
+
+    //then
+    assertThat(assertions).isInstanceOf(JobAssert.class);
+  }
+
+  @Test
+  @DisplayName("Should return DeploymentAssert for DeploymentEvent")
+  void testAssertThatDeploymentEventReturnsDeploymentAssert() {
+    // given
+    DeploymentEvent event = mock(DeploymentEvent.class);
+
+    // when
+    DeploymentAssert assertions = BpmnAssert.assertThat(event);
+
+    //then
+    assertThat(assertions).isInstanceOf(DeploymentAssert.class);
+  }
+
+  @Test
+  @DisplayName("Should return MessageAssert for PublishMessageResponse")
+  void testAssertThatPublishMessageResponseReturnsMessageAssert() {
+    // given
+    PublishMessageResponse event = mock(PublishMessageResponse.class);
+
+    // when
+    MessageAssert assertions = BpmnAssert.assertThat(event);
+
+    //then
+    assertThat(assertions).isInstanceOf(MessageAssert.class);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We already had an entry point for ProcessInstanceEvents, but we missed the ProcessInstanceResults. This change adds this entry point for allowing easy assertions when users have a ProcessInstanceResult.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #167 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [x] The documentation is updated
