### PR TITLE
Containerize in memory engine

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,7 @@
 name: Build and test
 on:
   pull_request: { }
+  workflow_call: { }
 jobs:
   build-and-test:
     name: Run tests on ${{ matrix.os }}

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -4,7 +4,7 @@
 #        deploys a RELEASE with the selected version
 #        updates the project version by incrementing the patch version
 #        commits the version update change to the repository's default branch (main).
-name: Deploy artifacts with Maven
+name: Deploy artifacts
 on:
   push:
     branches: [main]
@@ -15,7 +15,7 @@ jobs:
   test:
     uses: ./.github/workflows/build-test.yml
 
-  build:
+  deploy-to-maven:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
@@ -59,7 +59,7 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
-      - name: Deploy SNAPSHOT / Release
+      - name: Build and deploy to Maven
         id: release
         uses: camunda-community-hub/community-action-maven-release@v1.0.12
         with:
@@ -83,3 +83,65 @@ jobs:
           asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
           asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
           asset_content_type: application/zip
+
+  deploy-to-docker:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    env:
+      OWNER: "camunda"
+      IMAGE_NAME: "zeebe-process-test-engine"
+      TAG: "latest"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
+
+      - name: Set up Java environment
+        uses: actions/setup-java@v2.5.0
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Build jar
+        run: |
+          cd engine
+          mvn clean package -DskipTests
+
+      - name: Build Docker image
+        run: |
+          if ! echo $TAG | grep SNAPSHOT; then
+            echo ${{ github.event.release.tag_name }} >> $TAG
+          fi
+          cd engine
+          docker build . -t $IMAGE_NAME:$TAG
+
+      - name: Push Docker image
+        run: |
+          echo '${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}' | docker login -u '${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}' --password-stdin
+          echo $IMAGE_NAME
+          echo $TAG
+          IMAGE_ID=$OWNER/$IMAGE_NAME
+          echo $IMAGE_ID
+          docker tag $IMAGE_NAME $IMAGE_ID:$TAG
+          docker push $IMAGE_ID:$TAG

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -12,8 +12,12 @@ on:
     types: [published]
   workflow_dispatch: { }
 jobs:
+  test:
+    uses: ./.github/workflows/build-test.yml
+
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    needs: [test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +63,6 @@ jobs:
         id: release
         uses: camunda-community-hub/community-action-maven-release@v1.0.12
         with:
-          run-tests: true
           release-version: ${{ github.event.release.tag_name }}
           release-profile: community-action-maven-release
           nexus-usr: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
@@ -80,18 +83,3 @@ jobs:
           asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
           asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
           asset_content_type: application/zip
-
-      - name: Archive Test Results on Failure
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: test-results
-          path: target/surefire-reports/
-          retention-days: 7
-
-      - name: Publish Unit Test Results
-        id: publish
-        uses: EnricoMi/publish-unit-test-result-action@v1.28
-        if: failure()
-        with:
-          files: target/surefire-reports/*.xml

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -34,4 +34,4 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          files: "artifacts/**/surefire-reports/*.xml"

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-alpine
+
+COPY target/zeebe-process-test-engine-*-jar-with-dependencies.jar /app.jar
+
+CMD ["java", "-jar", "/app.jar"]

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -47,6 +47,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+
+    <!-- Test Scope -->
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
@@ -57,5 +63,32 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>io.camunda.zeebe.process.test.engine.ZeebeProcessTestEngine</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/EngineFactory.java
@@ -5,11 +5,12 @@ import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
-import io.camunda.zeebe.logstreams.log.*;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
+import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
 import io.camunda.zeebe.process.test.engine.db.InMemoryDbFactory;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
@@ -24,7 +25,7 @@ public class EngineFactory {
   public static InMemoryEngine create() {
     final int partitionId = 1;
     final int partitionCount = 1;
-    final int port = SocketUtil.getNextAddress().getPort();
+    final int port = 26500;
 
     final ControlledActorClock clock = createActorClock();
     final ActorScheduler scheduler = createAndStartActorScheduler(clock);

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/ZeebeProcessTestEngine.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/ZeebeProcessTestEngine.java
@@ -1,0 +1,11 @@
+package io.camunda.zeebe.process.test.engine;
+
+import io.camunda.zeebe.process.test.api.InMemoryEngine;
+
+public class ZeebeProcessTestEngine {
+
+  public static void main(String[] args) {
+    final InMemoryEngine engine = EngineFactory.create();
+    engine.start();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
         <scope>import</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${dependency.slf4j.version}</version>
+      </dependency>
+
       <!-- Only for dependency convergence issues -->
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
1. Made the engine executable by adding a main class which creates and starts the engine. This required giving the gRPC server a static port, otherwise we won't know how to bind the containers ports later on. I've also created a Dockerfile to build the container.
2. Added a build step to the deploy-artifacts workflow which will build and push the container to docker hub.
3. Made the build-test workflow reusable, this way we can just call this workflow from the deploy-artifacts workflow and run all tests on different OSs, instead of relying on the community maven release plugin for testing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5 
Next steps will be done in #7 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
