### PR TITLE
Move containerized engine to different module

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Build jar
         run: |
-          cd engine
+          cd engine-agent
           mvn clean package -DskipTests
 
       - name: Build Docker image
@@ -133,7 +133,7 @@ jobs:
           if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
             TAG="${{ github.event.release.tag_name }}"
           fi
-          cd engine
+          cd engine-agent
           docker build . -t $IMAGE_NAME:$TAG
 
       - name: Push Docker image

--- a/engine-agent/Dockerfile
+++ b/engine-agent/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-alpine
+
+COPY target/*-jar-with-dependencies.jar /zeebe-process-test-engine.jar
+
+CMD ["java", "-jar", "/zeebe-process-test-engine.jar"]

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-process-test-root</artifactId>
+    <version>1.3.4-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-process-test-engine-agent</artifactId>
+  <version>1.3.4-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Zeebe Process Test Engine Agent</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-process-test-engine</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>io.camunda.zeebe.process.test.engine.agent.ZeebeProcessTestEngine</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/ZeebeProcessTestEngine.java
@@ -1,6 +1,7 @@
-package io.camunda.zeebe.process.test.engine;
+package io.camunda.zeebe.process.test.engine.agent;
 
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
+import io.camunda.zeebe.process.test.engine.EngineFactory;
 
 public class ZeebeProcessTestEngine {
 

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,5 +1,0 @@
-FROM openjdk:17-alpine
-
-COPY target/zeebe-process-test-engine-*-jar-with-dependencies.jar /zeebe-process-test-engine.jar
-
-CMD ["java", "-jar", "/zeebe-process-test-engine.jar"]

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -65,31 +65,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <archive>
-                <manifest>
-                  <mainClass>io.camunda.zeebe.process.test.engine.ZeebeProcessTestEngine</mainClass>
-                </manifest>
-              </archive>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>api</module>
     <module>assertions</module>
     <module>engine</module>
+    <module>engine-agent</module>
     <module>extension</module>
     <module>qa</module>
   </modules>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
A new "engine-agent" module has been created. This module will be responsible for containerizing the engine and making it executable. This has been split from the "engine" module, because in the near future we will support using the engine with and without testcontainers. For people running without testcontainers we don't want to expose any of the container related stuff.


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
