### PR TITLE
Isolate shared RecordStreamSource functionality

### DIFF
--- a/api/src/main/java/io/camunda/zeebe/process/test/api/InMemoryEngine.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/InMemoryEngine.java
@@ -13,7 +13,7 @@ public interface InMemoryEngine {
   void stop();
 
   /** @return the {@link RecordStreamSource} of this engine */
-  RecordStreamSource getRecordStream();
+  RecordStreamSource getRecordStreamSource();
 
   /** @return a newly created {@link ZeebeClient} */
   ZeebeClient createClient();

--- a/api/src/main/java/io/camunda/zeebe/process/test/api/RecordStreamSource.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/RecordStreamSource.java
@@ -2,56 +2,9 @@ package io.camunda.zeebe.process.test.api;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.*;
-import io.camunda.zeebe.protocol.record.value.deployment.Process;
 
 public interface RecordStreamSource {
 
   /** @return an iterable of all {@link Record} */
   Iterable<Record<?>> records();
-
-  /** @return an iterable of all {@link Record<ProcessInstanceRecordValue>} */
-  Iterable<Record<ProcessInstanceRecordValue>> processInstanceRecords();
-
-  /** @return an iterable of all {@link Record<JobRecordValue>} */
-  Iterable<Record<JobRecordValue>> jobRecords();
-
-  /** @return an iterable of all {@link Record<JobBatchRecordValue>} */
-  Iterable<Record<JobBatchRecordValue>> jobBatchRecords();
-
-  /** @return an iterable of all {@link Record<DeploymentRecordValue>} */
-  Iterable<Record<DeploymentRecordValue>> deploymentRecords();
-
-  /** @return an iterable of all {@link Record<Process>} */
-  Iterable<Record<Process>> processRecords();
-
-  /** @return an iterable of all {@link Record<VariableRecordValue>} */
-  Iterable<Record<VariableRecordValue>> variableRecords();
-
-  /** @return an iterable of all {@link Record<VariableDocumentRecordValue>} */
-  Iterable<Record<VariableDocumentRecordValue>> variableDocumentRecords();
-
-  /** @return an iterable of all {@link Record<IncidentRecordValue>} */
-  Iterable<Record<IncidentRecordValue>> incidentRecords();
-
-  /** @return an iterable of all {@link Record<TimerRecordValue>} */
-  Iterable<Record<TimerRecordValue>> timerRecords();
-
-  /** @return an iterable of all {@link Record<MessageRecordValue>} */
-  Iterable<Record<MessageRecordValue>> messageRecords();
-
-  /** @return an iterable of all {@link Record<MessageSubscriptionRecordValue>} */
-  Iterable<Record<MessageSubscriptionRecordValue>> messageSubscriptionRecords();
-
-  /** @return an iterable of all {@link Record<MessageStartEventSubscriptionRecordValue>} */
-  Iterable<Record<MessageStartEventSubscriptionRecordValue>> messageStartEventSubscriptionRecords();
-
-  /** @return an iterable of all {@link Record<ProcessMessageSubscriptionRecordValue>} */
-  Iterable<Record<ProcessMessageSubscriptionRecordValue>> processMessageSubscriptionRecords();
-
-  /**
-   * Prints all records to the console
-   *
-   * @param compact enable compact logging
-   */
-  void print(final boolean compact);
 }

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/BpmnAssert.java
@@ -5,29 +5,29 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
 
 public abstract class BpmnAssert {
 
-  static ThreadLocal<RecordStreamSource> recordStreamSource = new ThreadLocal<>();
+  static ThreadLocal<RecordStream> recordStream = new ThreadLocal<>();
 
-  public static void initRecordStream(final RecordStreamSource recordStreamSource) {
-    BpmnAssert.recordStreamSource.set(recordStreamSource);
+  public static void initRecordStream(final RecordStream recordStream) {
+    BpmnAssert.recordStream.set(recordStream);
   }
 
   public static void resetRecordStream() {
-    recordStreamSource.remove();
+    recordStream.remove();
   }
 
-  public static RecordStreamSource getRecordStreamSource() {
-    if (recordStreamSource.get() == null) {
+  public static RecordStream getRecordStreamSource() {
+    if (recordStream.get() == null) {
       throw new AssertionError(
           "No RecordStreamSource is set. Please make sure you are using the "
               + "@ZeebeProcessTest annotation. Alternatively, set one manually using "
               + "BpmnAssert.initRecordStream.");
     }
-    return recordStreamSource.get();
+    return recordStream.get();
   }
 
   public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent instanceEvent) {

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/DeploymentAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/DeploymentAssert.java
@@ -5,19 +5,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.Process;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import java.util.List;
 import org.assertj.core.api.AbstractAssert;
 
 /** Assertions for {@code DeploymentEvent} instances */
 public class DeploymentAssert extends AbstractAssert<DeploymentAssert, DeploymentEvent> {
 
-  private final RecordStreamSource recordStreamSource;
+  private final RecordStream recordStream;
 
-  public DeploymentAssert(
-      final DeploymentEvent actual, final RecordStreamSource recordStreamSource) {
+  public DeploymentAssert(final DeploymentEvent actual, final RecordStream recordStream) {
     super(actual, DeploymentAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -79,7 +78,7 @@ public class DeploymentAssert extends AbstractAssert<DeploymentAssert, Deploymen
             bpmnProcessId, matchingProcesses.size(), matchingProcesses)
         .hasSize(1);
 
-    return new ProcessAssert(matchingProcesses.get(0), recordStreamSource);
+    return new ProcessAssert(matchingProcesses.get(0), recordStream);
   }
 
   /**
@@ -102,6 +101,6 @@ public class DeploymentAssert extends AbstractAssert<DeploymentAssert, Deploymen
             resourceName, matchingProcesses.size(), matchingProcesses)
         .hasSize(1);
 
-    return new ProcessAssert(matchingProcesses.get(0), recordStreamSource);
+    return new ProcessAssert(matchingProcesses.get(0), recordStream);
   }
 }

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.filters.IncidentRecordStreamFilter;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -20,11 +20,11 @@ import org.assertj.core.api.StringAssert;
 public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
   private final String LINE_SEPARATOR = System.lineSeparator();
 
-  private final RecordStreamSource recordStreamSource;
+  private final RecordStream recordStream;
 
-  public IncidentAssert(final long incidentKey, final RecordStreamSource recordStreamSource) {
+  public IncidentAssert(final long incidentKey, final RecordStream recordStream) {
     super(incidentKey, IncidentAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -198,7 +198,7 @@ public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
   }
 
   private IncidentRecordStreamFilter getIncidentRecords(final IncidentIntent intent) {
-    return StreamFilter.incident(recordStreamSource)
+    return StreamFilter.incident(recordStream)
         .withRejectionType(RejectionType.NULL_VAL)
         .withIncidentKey(actual)
         .withIntent(intent);

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
@@ -3,8 +3,8 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.filters.IncidentRecordStreamFilter;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -18,11 +18,11 @@ import org.assertj.core.data.Offset;
 /** Assertions for {@code ActivatedJob} instances */
 public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
 
-  private final RecordStreamSource recordStreamSource;
+  private final RecordStream recordStream;
 
-  public JobAssert(final ActivatedJob actual, final RecordStreamSource recordStreamSource) {
+  public JobAssert(final ActivatedJob actual, final RecordStream recordStream) {
     super(actual, JobAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -138,11 +138,11 @@ public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
     final Record<IncidentRecordValue> latestIncidentRecord =
         incidentCreatedRecords.get(incidentCreatedRecords.size() - 1);
 
-    return new IncidentAssert(latestIncidentRecord.getKey(), recordStreamSource);
+    return new IncidentAssert(latestIncidentRecord.getKey(), recordStream);
   }
 
   private IncidentRecordStreamFilter getIncidentCreatedRecords() {
-    return StreamFilter.incident(recordStreamSource)
+    return StreamFilter.incident(recordStream)
         .withRejectionType(RejectionType.NULL_VAL)
         .withJobKey(actual.getKey());
   }

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/MessageAssert.java
@@ -3,7 +3,7 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -20,12 +20,11 @@ import org.assertj.core.api.Assertions;
 
 public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageResponse> {
 
-  private RecordStreamSource recordStreamSource;
+  private RecordStream recordStream;
 
-  protected MessageAssert(
-      final PublishMessageResponse actual, final RecordStreamSource recordStreamSource) {
+  protected MessageAssert(final PublishMessageResponse actual, final RecordStream recordStream) {
     super(actual, MessageAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -35,7 +34,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasBeenCorrelated() {
     final boolean isCorrelated =
-        StreamFilter.processMessageSubscription(recordStreamSource)
+        StreamFilter.processMessageSubscription(recordStream)
             .withMessageKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
@@ -57,7 +56,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasNotBeenCorrelated() {
     final Optional<Record<ProcessMessageSubscriptionRecordValue>> recordOptional =
-        StreamFilter.processMessageSubscription(recordStreamSource)
+        StreamFilter.processMessageSubscription(recordStream)
             .withMessageKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
@@ -84,7 +83,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasCreatedProcessInstance() {
     final boolean isCorrelated =
-        StreamFilter.messageStartEventSubscription(recordStreamSource)
+        StreamFilter.messageStartEventSubscription(recordStream)
             .withMessageKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(MessageStartEventSubscriptionIntent.CORRELATED)
@@ -108,7 +107,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasNotCreatedProcessInstance() {
     final Optional<Record<MessageStartEventSubscriptionRecordValue>> recordOptional =
-        StreamFilter.messageStartEventSubscription(recordStreamSource)
+        StreamFilter.messageStartEventSubscription(recordStream)
             .withMessageKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(MessageStartEventSubscriptionIntent.CORRELATED)
@@ -135,7 +134,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasExpired() {
     final boolean isExpired =
-        StreamFilter.message(recordStreamSource)
+        StreamFilter.message(recordStream)
             .withKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(MessageIntent.EXPIRED)
@@ -157,7 +156,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    */
   public MessageAssert hasNotExpired() {
     final boolean isExpired =
-        StreamFilter.message(recordStreamSource)
+        StreamFilter.message(recordStream)
             .withKey(actual.getMessageKey())
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(MessageIntent.EXPIRED)
@@ -187,7 +186,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
             actual.getMessageKey(), correlatedProcessInstances.size(), correlatedProcessInstances)
         .hasSize(1);
 
-    return new ProcessInstanceAssert(correlatedProcessInstances.get(0), recordStreamSource);
+    return new ProcessInstanceAssert(correlatedProcessInstances.get(0), recordStream);
   }
 
   /**
@@ -196,7 +195,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    * @return List of process instance keys
    */
   private List<Long> getProcessInstanceKeysForCorrelatedMessage() {
-    return StreamFilter.processMessageSubscription(recordStreamSource)
+    return StreamFilter.processMessageSubscription(recordStream)
         .withMessageKey(actual.getMessageKey())
         .withRejectionType(RejectionType.NULL_VAL)
         .withIntent(ProcessMessageSubscriptionIntent.CORRELATED)
@@ -211,7 +210,7 @@ public class MessageAssert extends AbstractAssert<MessageAssert, PublishMessageR
    * @return List of process instance keys
    */
   private List<Long> getProcessInstanceKeysForCorrelatedMessageStartEvent() {
-    return StreamFilter.messageStartEventSubscription(recordStreamSource)
+    return StreamFilter.messageStartEventSubscription(recordStream)
         .withMessageKey(actual.getMessageKey())
         .withRejectionType(RejectionType.NULL_VAL)
         .withIntent(MessageStartEventSubscriptionIntent.CORRELATED)

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessAssert.java
@@ -3,7 +3,7 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.api.response.Process;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -31,11 +31,11 @@ import org.assertj.core.api.AbstractAssert;
  */
 public class ProcessAssert extends AbstractAssert<ProcessAssert, Process> {
 
-  private final RecordStreamSource recordStreamSource;
+  private final RecordStream recordStream;
 
-  public ProcessAssert(final Process actual, final RecordStreamSource recordStreamSource) {
+  public ProcessAssert(final Process actual, final RecordStream recordStream) {
     super(actual, ProcessAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -141,7 +141,7 @@ public class ProcessAssert extends AbstractAssert<ProcessAssert, Process> {
   }
 
   private Stream<Record<ProcessInstanceRecordValue>> getRecords() {
-    return StreamFilter.processInstance(recordStreamSource)
+    return StreamFilter.processInstance(recordStream)
         .withRejectionType(RejectionType.NULL_VAL)
         .withElementId(actual.getBpmnProcessId())
         .withBpmnElementType(BpmnElementType.PROCESS)

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
@@ -3,8 +3,8 @@ package io.camunda.zeebe.process.test.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.filters.IncidentRecordStreamFilter;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -22,11 +22,11 @@ import org.assertj.core.api.SoftAssertions;
 
 public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert, Long> {
 
-  private final RecordStreamSource recordStreamSource;
+  private final RecordStream recordStream;
 
-  public ProcessInstanceAssert(final long actual, final RecordStreamSource recordStreamSource) {
+  public ProcessInstanceAssert(final long actual, final RecordStream recordStream) {
     super(actual, ProcessInstanceAssert.class);
-    this.recordStreamSource = recordStreamSource;
+    this.recordStream = recordStream;
   }
 
   /**
@@ -37,7 +37,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   public ProcessInstanceAssert isStarted() {
     final boolean isStarted =
-        StreamFilter.processInstance(recordStreamSource)
+        StreamFilter.processInstance(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -58,7 +58,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   public ProcessInstanceAssert isActive() {
     final boolean isActive =
-        StreamFilter.processInstance(recordStreamSource)
+        StreamFilter.processInstance(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withBpmnElementType(BpmnElementType.PROCESS)
@@ -103,7 +103,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    * @return boolean indicating whether the process instance has been completed
    */
   private boolean isProcessInstanceCompleted() {
-    return StreamFilter.processInstance(recordStreamSource)
+    return StreamFilter.processInstance(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .withBpmnElementType(BpmnElementType.PROCESS)
@@ -143,7 +143,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    * @return boolean indicating whether the process instance has been terminated
    */
   private boolean isProcessInstanceTerminated() {
-    return StreamFilter.processInstance(recordStreamSource)
+    return StreamFilter.processInstance(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .withBpmnElementType(BpmnElementType.PROCESS)
@@ -185,7 +185,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   public ProcessInstanceAssert hasPassedElement(final String elementId, final int times) {
     final long count =
-        StreamFilter.processInstance(recordStreamSource)
+        StreamFilter.processInstance(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withElementId(elementId)
@@ -208,7 +208,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   public ProcessInstanceAssert hasPassedElementInOrder(final String... elementIds) {
     final List<String> foundElementRecords =
-        StreamFilter.processInstance(recordStreamSource)
+        StreamFilter.processInstance(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withElementIdIn(elementIds)
@@ -258,7 +258,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   private Set<String> getElementsInWaitState() {
     final Set<String> elementsInWaitState = new HashSet<>();
-    StreamFilter.processInstance(recordStreamSource)
+    StreamFilter.processInstance(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .withoutBpmnElementType(BpmnElementType.PROCESS)
@@ -293,7 +293,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
     final List<String> wrongfullyWaitingElementIds = new ArrayList<>();
     final List<String> wrongfullyNotWaitingElementIds = new ArrayList<>();
 
-    StreamFilter.processInstance(recordStreamSource)
+    StreamFilter.processInstance(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .withoutBpmnElementType(BpmnElementType.PROCESS)
@@ -364,7 +364,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    */
   private Set<String> getOpenMessageSubscriptions() {
     final Set<String> openMessageSubscriptions = new HashSet<>();
-    StreamFilter.processMessageSubscription(recordStreamSource)
+    StreamFilter.processMessageSubscription(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .stream()
@@ -397,7 +397,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
     assertThat(times).describedAs("Times").isGreaterThanOrEqualTo(0);
 
     final long actualTimes =
-        StreamFilter.processMessageSubscription(recordStreamSource)
+        StreamFilter.processMessageSubscription(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withMessageName(messageName)
@@ -427,7 +427,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
     assertThat(times).describedAs("Times").isGreaterThanOrEqualTo(0);
 
     final long actualTimes =
-        StreamFilter.processMessageSubscription(recordStreamSource)
+        StreamFilter.processMessageSubscription(recordStream)
             .withProcessInstanceKey(actual)
             .withRejectionType(RejectionType.NULL_VAL)
             .withCorrelationKey(correlationKey)
@@ -505,7 +505,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    * @return map of variables
    */
   private Map<String, String> getProcessInstanceVariables() {
-    return StreamFilter.variable(recordStreamSource)
+    return StreamFilter.variable(recordStream)
         .withProcessInstanceKey(actual)
         .withRejectionType(RejectionType.NULL_VAL)
         .stream()
@@ -563,11 +563,11 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
     final Record<IncidentRecordValue> latestIncidentRecord =
         incidentCreatedRecords.get(incidentCreatedRecords.size() - 1);
 
-    return new IncidentAssert(latestIncidentRecord.getKey(), recordStreamSource);
+    return new IncidentAssert(latestIncidentRecord.getKey(), recordStream);
   }
 
   private IncidentRecordStreamFilter getIncidentCreatedRecords() {
-    return StreamFilter.incident(recordStreamSource)
+    return StreamFilter.incident(recordStream)
         .withRejectionType(RejectionType.NULL_VAL)
         .withIntent(IncidentIntent.CREATED)
         .withProcessInstanceKey(actual);

--- a/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
+++ b/assertions/src/test/java/io/camunda/zeebe/process/test/assertions/BpmnAssertTest.java
@@ -8,7 +8,7 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +19,7 @@ class BpmnAssertTest {
 
   @BeforeEach
   void beforeEach() {
-    BpmnAssert.initRecordStream(mock(RecordStreamSource.class));
+    BpmnAssert.initRecordStream(mock(RecordStream.class));
   }
 
   @AfterEach

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/EngineControlImpl.java
@@ -92,7 +92,7 @@ public final class EngineControlImpl extends EngineControlImplBase {
   public void getRecords(
       final GetRecordsRequest request, final StreamObserver<RecordResponse> responseObserver) {
     final ObjectMapper mapper = new ObjectMapper();
-    final Iterable<Record<?>> records = engine.getRecordStream().records();
+    final Iterable<Record<?>> records = engine.getRecordStreamSource().records();
     for (final Record<?> record : records) {
       try {
         final String recordJson = mapper.writeValueAsString(record);

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -59,8 +59,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-process-test-filters</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngineImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngineImpl.java
@@ -79,7 +79,7 @@ public class InMemoryEngineImpl implements InMemoryEngine {
   }
 
   @Override
-  public RecordStreamSource getRecordStream() {
+  public RecordStreamSource getRecordStreamSource() {
     return recordStream;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/RecordStreamSourceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/RecordStreamSourceImpl.java
@@ -8,27 +8,9 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordValue;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
-import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
-import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
-import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
-import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
-import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
-import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
-import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
-import io.camunda.zeebe.protocol.record.value.deployment.Process;
-import io.camunda.zeebe.test.util.record.CompactRecordLogger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class RecordStreamSourceImpl implements RecordStreamSource {
 
@@ -46,95 +28,6 @@ public class RecordStreamSourceImpl implements RecordStreamSource {
   public Iterable<Record<?>> records() {
     updateWithNewRecords();
     return Collections.unmodifiableList(records);
-  }
-
-  <T extends RecordValue> Iterable<Record<T>> recordsOfValueType(final ValueType valueType) {
-    final Stream<Record<T>> stream =
-        (Stream)
-            StreamSupport.stream(records().spliterator(), false)
-                .filter((record) -> record.getValueType() == valueType);
-    return stream::iterator;
-  }
-
-  @Override
-  public Iterable<Record<ProcessInstanceRecordValue>> processInstanceRecords() {
-    return recordsOfValueType(ValueType.PROCESS_INSTANCE);
-  }
-
-  @Override
-  public Iterable<Record<JobRecordValue>> jobRecords() {
-    return recordsOfValueType(ValueType.JOB);
-  }
-
-  @Override
-  public Iterable<Record<JobBatchRecordValue>> jobBatchRecords() {
-    return recordsOfValueType(ValueType.JOB_BATCH);
-  }
-
-  @Override
-  public Iterable<Record<DeploymentRecordValue>> deploymentRecords() {
-    return recordsOfValueType(ValueType.DEPLOYMENT);
-  }
-
-  @Override
-  public Iterable<Record<Process>> processRecords() {
-    return recordsOfValueType(ValueType.PROCESS);
-  }
-
-  @Override
-  public Iterable<Record<VariableRecordValue>> variableRecords() {
-    return recordsOfValueType(ValueType.VARIABLE);
-  }
-
-  @Override
-  public Iterable<Record<VariableDocumentRecordValue>> variableDocumentRecords() {
-    return recordsOfValueType(ValueType.VARIABLE_DOCUMENT);
-  }
-
-  @Override
-  public Iterable<Record<IncidentRecordValue>> incidentRecords() {
-    return recordsOfValueType(ValueType.INCIDENT);
-  }
-
-  @Override
-  public Iterable<Record<TimerRecordValue>> timerRecords() {
-    return recordsOfValueType(ValueType.TIMER);
-  }
-
-  @Override
-  public Iterable<Record<MessageRecordValue>> messageRecords() {
-    return recordsOfValueType(ValueType.MESSAGE);
-  }
-
-  @Override
-  public Iterable<Record<MessageSubscriptionRecordValue>> messageSubscriptionRecords() {
-    return recordsOfValueType(ValueType.MESSAGE_SUBSCRIPTION);
-  }
-
-  @Override
-  public Iterable<Record<MessageStartEventSubscriptionRecordValue>>
-      messageStartEventSubscriptionRecords() {
-    return recordsOfValueType(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION);
-  }
-
-  @Override
-  public Iterable<Record<ProcessMessageSubscriptionRecordValue>>
-      processMessageSubscriptionRecords() {
-    return recordsOfValueType(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
-  }
-
-  @Override
-  public void print(final boolean compact) {
-    final List<Record<?>> recordsList = new ArrayList<>();
-    records().forEach(recordsList::add);
-
-    if (compact) {
-      new CompactRecordLogger(recordsList).log();
-    } else {
-      System.out.println("===== records (count: ${count()}) =====");
-      recordsList.forEach(record -> System.out.println(record.toJson()));
-      System.out.println("---------------------------");
-    }
   }
 
   private void updateWithNewRecords() {

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/PrintRecordStreamExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/PrintRecordStreamExtension.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.process.test.engine;
 
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
@@ -24,7 +25,7 @@ class PrintRecordStreamExtension implements TestWatcher {
           (InMemoryEngine) zeebeEngineField.get(context.getRequiredTestInstance());
 
       System.out.println("===== Test failed! Printing records from the stream:");
-      zeebeEngine.getRecordStream().print(true);
+      RecordStream.of(zeebeEngine.getRecordStreamSource()).print(true);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
+++ b/extension/src/main/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtension.java
@@ -2,9 +2,9 @@ package io.camunda.zeebe.process.test.extension;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.engine.EngineFactory;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +26,7 @@ public class ZeebeProcessTestExtension
   public void beforeEach(final ExtensionContext extensionContext) {
     final InMemoryEngine engine = EngineFactory.create();
     final ZeebeClient client = engine.createClient();
-    final RecordStreamSource recordStream = engine.getRecordStream();
+    final RecordStream recordStream = RecordStream.of(engine.getRecordStreamSource());
 
     try {
       injectFields(extensionContext, engine, client, recordStream);
@@ -62,7 +62,7 @@ public class ZeebeProcessTestExtension
     final InMemoryEngine engine = (InMemoryEngine) engineContent;
 
     System.out.println("===== Test failed! Printing records from the stream:");
-    engine.getRecordStream().print(true);
+    RecordStream.of(engine.getRecordStreamSource()).print(true);
   }
 
   private void injectFields(final ExtensionContext extensionContext, final Object... objects) {

--- a/extension/src/test/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtensionTest.java
+++ b/extension/src/test/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtensionTest.java
@@ -3,7 +3,7 @@ package io.camunda.zeebe.process.test.extension;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -14,8 +14,8 @@ class ZeebeProcessTestExtensionTest {
   @Nested
   class MultipleInjectedFields {
 
-    private RecordStreamSource recordStreamSourceOne;
-    private RecordStreamSource recordStreamSourceTwo;
+    private RecordStream recordStreamOne;
+    private RecordStream recordStreamTwo;
 
     @Test
     public void testMultipleInjectedFieldsThrowError() {
@@ -31,8 +31,8 @@ class ZeebeProcessTestExtensionTest {
       assertThatThrownBy(() -> extension.beforeEach(extensionContext))
           .isInstanceOf(IllegalStateException.class)
           .hasMessage(
-              "Expected at most one field of type RecordStreamSourceImpl, but found 2. "
-                  + "Please make sure at most one field of type RecordStreamSourceImpl has been "
+              "Expected at most one field of type RecordStream, but found 2. "
+                  + "Please make sure at most one field of type RecordStream has been "
                   + "declared in the test class.");
     }
   }

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -28,6 +28,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/RecordStream.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/RecordStream.java
@@ -1,0 +1,128 @@
+package io.camunda.zeebe.process.test.filters;
+
+import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecordStream {
+
+  private static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.process.test");
+
+  private RecordStreamSource recordStreamSource;
+
+  public RecordStream(final RecordStreamSource recordStreamSource) {
+    this.recordStreamSource = recordStreamSource;
+  }
+
+  public static RecordStream of(final RecordStreamSource recordStreamSource) {
+    return new RecordStream(recordStreamSource);
+  }
+
+  public Iterable<Record<?>> records() {
+    return recordStreamSource.records();
+  }
+
+  <T extends RecordValue> Iterable<Record<T>> recordsOfValueType(final ValueType valueType) {
+    final Stream<Record<T>> stream =
+        (Stream)
+            StreamSupport.stream(recordStreamSource.records().spliterator(), false)
+                .filter((record) -> record.getValueType() == valueType);
+    return stream::iterator;
+  }
+
+  public Iterable<Record<ProcessInstanceRecordValue>> processInstanceRecords() {
+    return recordsOfValueType(ValueType.PROCESS_INSTANCE);
+  }
+
+  public Iterable<Record<JobRecordValue>> jobRecords() {
+    return recordsOfValueType(ValueType.JOB);
+  }
+
+  public Iterable<Record<JobBatchRecordValue>> jobBatchRecords() {
+    return recordsOfValueType(ValueType.JOB_BATCH);
+  }
+
+  public Iterable<Record<DeploymentRecordValue>> deploymentRecords() {
+    return recordsOfValueType(ValueType.DEPLOYMENT);
+  }
+
+  public Iterable<Record<Process>> processRecords() {
+    return recordsOfValueType(ValueType.PROCESS);
+  }
+
+  public Iterable<Record<VariableRecordValue>> variableRecords() {
+    return recordsOfValueType(ValueType.VARIABLE);
+  }
+
+  public Iterable<Record<VariableDocumentRecordValue>> variableDocumentRecords() {
+    return recordsOfValueType(ValueType.VARIABLE_DOCUMENT);
+  }
+
+  public Iterable<Record<IncidentRecordValue>> incidentRecords() {
+    return recordsOfValueType(ValueType.INCIDENT);
+  }
+
+  public Iterable<Record<TimerRecordValue>> timerRecords() {
+    return recordsOfValueType(ValueType.TIMER);
+  }
+
+  public Iterable<Record<MessageRecordValue>> messageRecords() {
+    return recordsOfValueType(ValueType.MESSAGE);
+  }
+
+  public Iterable<Record<MessageSubscriptionRecordValue>> messageSubscriptionRecords() {
+    return recordsOfValueType(ValueType.MESSAGE_SUBSCRIPTION);
+  }
+
+  public Iterable<Record<MessageStartEventSubscriptionRecordValue>>
+      messageStartEventSubscriptionRecords() {
+    return recordsOfValueType(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION);
+  }
+
+  public Iterable<Record<ProcessMessageSubscriptionRecordValue>>
+      processMessageSubscriptionRecords() {
+    return recordsOfValueType(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
+  }
+
+  public void print(final boolean compact) {
+    final List<Record<?>> recordsList = new ArrayList<>();
+    recordStreamSource.records().forEach(recordsList::add);
+
+    if (compact) {
+      final StringBuilder stringBuilder = new StringBuilder();
+      recordsList.forEach(
+          record ->
+              stringBuilder
+                  .append(record.getRecordType())
+                  .append(" ")
+                  .append(record.getValueType())
+                  .append(" ")
+                  .append(record.getIntent()));
+      LOG.info(stringBuilder.toString());
+    } else {
+      System.out.println("===== records (count: ${count()}) =====");
+      recordsList.forEach(record -> System.out.println(record.toJson()));
+      System.out.println("---------------------------");
+    }
+  }
+}

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/RecordStream.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/RecordStream.java
@@ -30,7 +30,7 @@ public class RecordStream {
 
   private RecordStreamSource recordStreamSource;
 
-  public RecordStream(final RecordStreamSource recordStreamSource) {
+  private RecordStream(final RecordStreamSource recordStreamSource) {
     this.recordStreamSource = recordStreamSource;
   }
 

--- a/filters/src/main/java/io/camunda/zeebe/process/test/filters/StreamFilter.java
+++ b/filters/src/main/java/io/camunda/zeebe/process/test/filters/StreamFilter.java
@@ -1,48 +1,45 @@
 package io.camunda.zeebe.process.test.filters;
 
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
-
 public class StreamFilter {
 
-  public static ProcessInstanceRecordStreamFilter processInstance(
-      final RecordStreamSource recordStreamSource) {
-    return new ProcessInstanceRecordStreamFilter(recordStreamSource.processInstanceRecords());
+  public static ProcessInstanceRecordStreamFilter processInstance(final RecordStream recordStream) {
+    return new ProcessInstanceRecordStreamFilter(recordStream.processInstanceRecords());
   }
 
   public static ProcessMessageSubscriptionRecordStreamFilter processMessageSubscription(
-      final RecordStreamSource recordStreamSource) {
+      final RecordStream recordStream) {
     return new ProcessMessageSubscriptionRecordStreamFilter(
-        recordStreamSource.processMessageSubscriptionRecords());
+        recordStream.processMessageSubscriptionRecords());
   }
 
-  public static VariableRecordStreamFilter variable(final RecordStreamSource recordStreamSource) {
-    return new VariableRecordStreamFilter(recordStreamSource.variableRecords());
+  public static VariableRecordStreamFilter variable(final RecordStream recordStream) {
+    return new VariableRecordStreamFilter(recordStream.variableRecords());
   }
 
-  public static MessageRecordStreamFilter message(final RecordStreamSource recordStreamSource) {
-    return new MessageRecordStreamFilter(recordStreamSource.messageRecords());
+  public static MessageRecordStreamFilter message(final RecordStream recordStream) {
+    return new MessageRecordStreamFilter(recordStream.messageRecords());
   }
 
-  public static IncidentRecordStreamFilter incident(final RecordStreamSource recordStreamSource) {
-    return new IncidentRecordStreamFilter(recordStreamSource.incidentRecords());
+  public static IncidentRecordStreamFilter incident(final RecordStream recordStream) {
+    return new IncidentRecordStreamFilter(recordStream.incidentRecords());
   }
 
   public static MessageStartEventSubscriptionStreamFilter messageStartEventSubscription(
-      final RecordStreamSource recordStreamSource) {
+      final RecordStream recordStream) {
     return new MessageStartEventSubscriptionStreamFilter(
-        recordStreamSource.messageStartEventSubscriptionRecords());
+        recordStream.messageStartEventSubscriptionRecords());
   }
 
   public static ProcessEventRecordStreamFilter processEventRecords(
-      final RecordStreamSource recordStreamSource) {
-    return new ProcessEventRecordStreamFilter(recordStreamSource.records());
+      final RecordStream recordStream) {
+    return new ProcessEventRecordStreamFilter(recordStream.records());
   }
 
-  public static JobRecordStreamFilter jobRecords(final RecordStreamSource recordStreamSource) {
-    return new JobRecordStreamFilter(recordStreamSource.jobRecords());
+  public static JobRecordStreamFilter jobRecords(final RecordStream recordStream) {
+    return new JobRecordStreamFilter(recordStream.jobRecords());
   }
 
-  public static TimerRecordStreamFilter timerRecords(final RecordStreamSource recordStreamSource) {
-    return new TimerRecordStreamFilter(recordStreamSource.timerRecords());
+  public static TimerRecordStreamFilter timerRecords(final RecordStream recordStream) {
+    return new TimerRecordStreamFilter(recordStream.timerRecords());
   }
 }

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/multithread/MultiThreadTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/multithread/MultiThreadTest.java
@@ -7,9 +7,9 @@ import static io.camunda.zeebe.process.test.qa.util.Utilities.startProcessInstan
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
-import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.extension.ZeebeProcessTest;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.qa.util.Utilities.ProcessPackStartEndEvent;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +29,7 @@ public class MultiThreadTest {
 
   private InMemoryEngine engine;
   private ZeebeClient client;
-  private RecordStreamSource recordStreamSource;
+  private RecordStream recordStream;
   private ExecutorService executorService;
 
   @BeforeEach
@@ -66,7 +66,7 @@ public class MultiThreadTest {
 
     @Override
     public Boolean call() {
-      BpmnAssert.initRecordStream(recordStreamSource);
+      BpmnAssert.initRecordStream(recordStream);
 
       deployProcess(client, ProcessPackStartEndEvent.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
@@ -7,6 +7,7 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
 import io.camunda.zeebe.process.test.api.InMemoryEngine;
+import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.filters.StreamFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -162,7 +163,7 @@ public class Utilities {
   public static void completeTask(
       final InMemoryEngine engine, final ZeebeClient client, final String taskId) {
     final List<Record<JobRecordValue>> records =
-        StreamFilter.jobRecords(engine.getRecordStream())
+        StreamFilter.jobRecords(RecordStream.of(engine.getRecordStreamSource()))
             .withElementId(taskId)
             .withIntent(JobIntent.CREATED)
             .stream()


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The `RecordStreamSource` interface defines a lot of methods that generic and should be reusable. This PR creates a new `RecordStream` class in the `filters` module. This class will implement these generic functions, so not all `RecordStreamSource` classes have to implement them separately, preventing duplication.

It's quite a refactoring so I've done it in a few steps to make it easier to review:
1. Create the `RecordStream` class containing the shared functionality.
2. Remove the shared functionality from the `RecordStreamSource` interface and the implementation.
3. Use the new `RecordStream` class in the `engine` module.
4. Make the filters in the `filters` module use the new `RecordStream` class.
5. Switch the `RecordStreamSource` to the new `RecordStream` in the other modules.


In Zeebe we have a similar functionality in the `RecordingExporter`. It would be nice if we could share this functionality between the 2 projects at some time. We can't use the zeebe implementation at the moment because it is not Java 8 compatible.

## Related issues

<!-- Which issues are closed by this PR or are related -->

This is a requirement for #192 . Without doing this #192 would introduce a lot of duplication as it needs create an implementation of the `RecordStreamSource` interface.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
