### PR TITLE
Fix sed commands

### DIFF
--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -84,8 +84,8 @@ jobs:
           git pull
           cd extension-testcontainer/src/main/resources
           IMAGE_ID=$OWNER/$IMAGE_NAME
-          sed -i '/container.image.name=/ s/=.*/=$IMAGE_ID/' config.properties
-          sed -i '/container.image.tag=/ s/=.*/=$TAG/' config.properties
+          sed -i '/container.image.name=/ s:=.*:='$IMAGE_ID':' config.properties
+          sed -i '/container.image.tag=/ s:=.*:='$TAG':' config.properties
           if [[ `git status --porcelain --untracked-files=no` ]]; then
             git commit -am "(release): update image and tag ($IMAGE_ID:$TAG)"
             git push


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Variable substitution did not work properly. This had 2 reasons. First, the `$IMAGE_ID` and `$TAG` were part of the string and got replaced as these strings.
Second, the `$IMAGE_ID` contains a `/`. This is also the character used as a delimiter in sed. The delimiter has now been changed to `:`.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
