### PR TITLE
Remove public from test methods

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/EngineClientTest.java
@@ -50,20 +50,20 @@ class EngineClientTest {
   private ZeebeClient zeebeClient;
 
   @BeforeEach
-  public void setupGrpcServer() {
+  void setupGrpcServer() {
     zeebeEngine = EngineFactory.create();
     zeebeEngine.start();
     zeebeClient = zeebeEngine.createClient();
   }
 
   @AfterEach
-  public void tearDown() {
+  void tearDown() {
     zeebeEngine.stop();
     zeebeClient.close();
   }
 
   @Test
-  public void shouldRequestTopology() {
+  void shouldRequestTopology() {
     // given
 
     // when
@@ -89,7 +89,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldUseBuiltInClient() {
+  void shouldUseBuiltInClient() {
     // given
 
     // when
@@ -100,7 +100,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldUseGatewayAddressToBuildClient() {
+  void shouldUseGatewayAddressToBuildClient() {
     // given
     final ZeebeClient client =
         ZeebeClient.newClientBuilder()
@@ -117,7 +117,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldPublishMessage() {
+  void shouldPublishMessage() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -156,7 +156,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldDeployProcess() {
+  void shouldDeployProcess() {
     // given
 
     // when
@@ -182,7 +182,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldCreateInstanceWithoutVariables() {
+  void shouldCreateInstanceWithoutVariables() {
     // given
     final DeploymentEvent deployment =
         zeebeClient
@@ -211,7 +211,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldRejectCommand() {
+  void shouldRejectCommand() {
     // given
 
     // when
@@ -226,7 +226,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldCreateProcessInstance() {
+  void shouldCreateProcessInstance() {
     // given
     final DeploymentEvent deployment =
         zeebeClient
@@ -256,7 +256,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldCancelProcessInstance() {
+  void shouldCancelProcessInstance() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -299,7 +299,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldUpdateVariablesOnProcessInstance() {
+  void shouldUpdateVariablesOnProcessInstance() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -337,7 +337,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldCreateProcessInstanceWithResult() {
+  void shouldCreateProcessInstanceWithResult() {
     // given
     final DeploymentEvent deployment =
         zeebeClient
@@ -369,7 +369,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldActivateJob() {
+  void shouldActivateJob() {
     // given
     final DeploymentEvent deployment =
         zeebeClient
@@ -423,7 +423,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldCompleteJob() {
+  void shouldCompleteJob() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -460,7 +460,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldFailJob() {
+  void shouldFailJob() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -527,7 +527,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldThrowErrorOnJob() {
+  void shouldThrowErrorOnJob() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -600,7 +600,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldUpdateRetiresOnJob() {
+  void shouldUpdateRetiresOnJob() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -661,7 +661,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldReadProcessInstanceRecords() {
+  void shouldReadProcessInstanceRecords() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -719,7 +719,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldPrintRecords() {
+  void shouldPrintRecords() {
     // given
     zeebeClient
         .newDeployCommand()
@@ -756,7 +756,7 @@ class EngineClientTest {
   }
 
   @Test
-  public void shouldIncreaseTheTime() {
+  void shouldIncreaseTheTime() {
     // given
     zeebeClient
         .newDeployCommand()

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/DbStringColumnFamilyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/DbStringColumnFamilyTest.java
@@ -28,7 +28,7 @@ public final class DbStringColumnFamilyTest {
   private DbString value;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     zeebeDb = dbFactory.createDb();
 
     key = new DbString();
@@ -39,7 +39,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutValue() {
+  void shouldPutValue() {
     // given
     key.wrapString("foo");
     value.wrapString("baring");
@@ -59,7 +59,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseForeachValue() {
+  void shouldUseForeachValue() {
     // given
     putKeyValuePair("foo", "baring");
     putKeyValuePair("this is the one", "as you know");
@@ -76,7 +76,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseForeachPair() {
+  void shouldUseForeachPair() {
     // given
     putKeyValuePair("foo", "baring");
     putKeyValuePair("this is the one", "as you know");
@@ -99,7 +99,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseWhileTrue() {
+  void shouldUseWhileTrue() {
     // given
     putKeyValuePair("foo", "baring");
     putKeyValuePair("this is the one", "as you know");
@@ -124,7 +124,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseWhileEqualPrefix() {
+  void shouldUseWhileEqualPrefix() {
     // given
     putKeyValuePair("foo", "baring");
     putKeyValuePair("this is the one", "as you know");
@@ -154,7 +154,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseWhileEqualPrefixLikeGet() {
+  void shouldUseWhileEqualPrefixLikeGet() {
     // given
     putKeyValuePair("foo", "baring");
     putKeyValuePair("this is the one", "as you know");
@@ -181,7 +181,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldAllowSingleNestedWhileEqualPrefix() {
+  void shouldAllowSingleNestedWhileEqualPrefix() {
     // given
     putKeyValuePair("and", "be good");
     key.wrapString("and");
@@ -197,7 +197,7 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldThrowExceptionOnMultipleNestedWhileEqualPrefix() {
+  void shouldThrowExceptionOnMultipleNestedWhileEqualPrefix() {
     // given
     putKeyValuePair("and", "be good");
     key.wrapString("and");

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbColumnFamilyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbColumnFamilyTest.java
@@ -27,7 +27,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   private DbLong value;
 
   @BeforeEach
-  public void setup() throws Exception {
+  void setup() throws Exception {
     zeebeDb = dbFactory.createDb();
 
     key = new DbLong();
@@ -38,7 +38,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutValue() {
+  void shouldPutValue() {
     // given
     key.wrapLong(1213);
     value.wrapLong(255);
@@ -58,7 +58,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldReturnNullIfNotExist() {
+  void shouldReturnNullIfNotExist() {
     // given
     key.wrapLong(1213);
 
@@ -70,7 +70,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutMultipleValues() {
+  void shouldPutMultipleValues() {
     // given
     putKeyValuePair(1213, 255);
 
@@ -93,7 +93,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutAndGetMultipleValues() {
+  void shouldPutAndGetMultipleValues() {
     // given
     putKeyValuePair(1213, 255);
 
@@ -118,7 +118,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldCheckForExistence() {
+  void shouldCheckForExistence() {
     // given
     putKeyValuePair(1213, 255);
 
@@ -130,7 +130,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldNotExist() {
+  void shouldNotExist() {
     // given
     key.wrapLong(1213);
 
@@ -142,7 +142,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldDelete() {
+  void shouldDelete() {
     // given
     putKeyValuePair(1213, 255);
 
@@ -158,7 +158,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldNotDeleteDifferentKey() {
+  void shouldNotDeleteDifferentKey() {
     // given
     putKeyValuePair(1213, 255);
 
@@ -177,7 +177,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseForeachValue() {
+  void shouldUseForeachValue() {
     // given
     putKeyValuePair(4567, 123);
     putKeyValuePair(6734, 921);
@@ -194,7 +194,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseForeachPair() {
+  void shouldUseForeachPair() {
     // given
     putKeyValuePair(4567, 123);
     putKeyValuePair(6734, 921);
@@ -217,7 +217,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldDeleteOnForeachPair() {
+  void shouldDeleteOnForeachPair() {
     // given
     putKeyValuePair(4567, 123);
     putKeyValuePair(6734, 921);
@@ -256,7 +256,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldUseWhileTrue() {
+  void shouldUseWhileTrue() {
     // given
     putKeyValuePair(4567, 123);
     putKeyValuePair(6734, 921);
@@ -281,7 +281,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldDeleteWhileTrue() {
+  void shouldDeleteWhileTrue() {
     // given
     putKeyValuePair(4567, 123);
     putKeyValuePair(6734, 921);
@@ -310,7 +310,7 @@ public final class InMemoryZeebeDbColumnFamilyTest {
   }
 
   @Test
-  public void shouldCheckIfEmpty() {
+  void shouldCheckIfEmpty() {
     assertThat(columnFamily.isEmpty()).isTrue();
 
     putKeyValuePair(1, 10);

--- a/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/process/test/engine/db/InMemoryZeebeDbTransactionTest.java
@@ -38,7 +38,7 @@ public final class InMemoryZeebeDbTransactionTest {
   private DbLong threeValue;
 
   @BeforeEach
-  public void setup() throws Exception {
+  void setup() throws Exception {
     final ZeebeDb<ColumnFamilies> zeebeDb = dbFactory.createDb();
     transactionContext = zeebeDb.createContext();
 
@@ -59,7 +59,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldUseTransaction() {
+  void shouldUseTransaction() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -85,7 +85,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldNotGetPreviousValue() {
+  void shouldNotGetPreviousValue() {
     // given
     oneKey.wrapLong(123);
     oneValue.wrapLong(456);
@@ -105,7 +105,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldStartNewTransaction() throws Exception {
+  void shouldStartNewTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -135,7 +135,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldAccessOnOpenTransaction() throws Exception {
+  void shouldAccessOnOpenTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -165,7 +165,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldNotReopenTransaction() throws Exception {
+  void shouldNotReopenTransaction() throws Exception {
     // given
     final ZeebeDbTransaction transaction = transactionContext.getCurrentTransaction();
 
@@ -181,7 +181,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldNotReopenTransactionWithOperations() {
+  void shouldNotReopenTransactionWithOperations() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -218,7 +218,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldRollbackTransaction() throws Exception {
+  void shouldRollbackTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -247,7 +247,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldGetValueInTransaction() {
+  void shouldGetValueInTransaction() {
     // given
     final AtomicLong actualValue = new AtomicLong(0);
     oneKey.wrapLong(1);
@@ -266,7 +266,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldFindValueInTransaction() {
+  void shouldFindValueInTransaction() {
     // given
     final Map<Long, Long> actualValues = new HashMap<>();
     oneKey.wrapLong(1);
@@ -299,7 +299,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldIterateAndFindValuesInTransaction() {
+  void shouldIterateAndFindValuesInTransaction() {
     // given
     final Map<Long, Long> actualValues = new HashMap<>();
 
@@ -336,7 +336,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldIterateAndDeleteInTransaction() {
+  void shouldIterateAndDeleteInTransaction() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -357,7 +357,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldEndInSameTransaction() {
+  void shouldEndInSameTransaction() {
     // given
     final AtomicLong actualValue = new AtomicLong(0);
     oneKey.wrapLong(1);
@@ -381,7 +381,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldWriteAndDeleteInTransaction() {
+  void shouldWriteAndDeleteInTransaction() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -419,7 +419,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldWriteAndDeleteSameKeyValuePairInTransaction() {
+  void shouldWriteAndDeleteSameKeyValuePairInTransaction() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -439,7 +439,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldNotCommitOnError() {
+  void shouldNotCommitOnError() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -472,7 +472,7 @@ public final class InMemoryZeebeDbTransactionTest {
   }
 
   @Test
-  public void shouldWriteKeyAfterDeletion() {
+  void shouldWriteKeyAfterDeletion() {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);

--- a/extension/src/test/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtensionTest.java
+++ b/extension/src/test/java/io/camunda/zeebe/process/test/extension/ZeebeProcessTestExtensionTest.java
@@ -18,7 +18,7 @@ class ZeebeProcessTestExtensionTest {
     private RecordStream recordStreamTwo;
 
     @Test
-    public void testMultipleInjectedFieldsThrowError() {
+    void testMultipleInjectedFieldsThrowError() {
       // given
       final ZeebeProcessTestExtension extension = new ZeebeProcessTestExtension();
       final ExtensionContext extensionContext = mock(ExtensionContext.class);

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/DeploymentAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/DeploymentAssertTest.java
@@ -26,7 +26,7 @@ class DeploymentAssertTest {
     private ZeebeClient client;
 
     @Test
-    public void testContainsProcessesById() {
+    void testContainsProcessesById() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcesses(
@@ -41,7 +41,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testContainsProcessesByResourceName() {
+    void testContainsProcessesByResourceName() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcesses(
@@ -56,7 +56,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByBpmnProcessId() {
+    void testExtractingProcessByBpmnProcessId() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -71,7 +71,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByResourceName() {
+    void testExtractingProcessByResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -93,7 +93,7 @@ class DeploymentAssertTest {
     private ZeebeClient client;
 
     @Test
-    public void testContainsProcessesByIdFailure() {
+    void testContainsProcessesByIdFailure() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -108,7 +108,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testContainsProcessesByResourceNameFailure() {
+    void testContainsProcessesByResourceNameFailure() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -123,7 +123,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByBpmnProcessIdFailure() {
+    void testExtractingProcessByBpmnProcessIdFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -139,7 +139,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByResourceName() {
+    void testExtractingProcessByResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessAssertTest.java
@@ -26,7 +26,7 @@ class ProcessAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testHasBPMNProcessId() {
+    void testHasBPMNProcessId() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -41,7 +41,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasVersion() {
+    void testHasVersion() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -56,7 +56,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasResourceName() {
+    void testHasResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -71,7 +71,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasAnyInstances() {
+    void testHasAnyInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -88,7 +88,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasNoInstances() {
+    void testHasNoInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -103,7 +103,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() {
+    void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -129,7 +129,7 @@ class ProcessAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testHasBPMNProcessIdFailure() {
+    void testHasBPMNProcessIdFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -148,7 +148,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasVersionFailure() {
+    void testHasVersionFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -165,7 +165,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasResourceNameFailure() {
+    void testHasResourceNameFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -184,7 +184,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasAnyInstancesFailure() {
+    void testHasAnyInstancesFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -201,7 +201,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasNoInstances() {
+    void testHasNoInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -220,7 +220,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() {
+    void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessInstanceAssertTest.java
@@ -44,7 +44,7 @@ class ProcessInstanceAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testProcessInstanceIsStarted() {
+    void testProcessInstanceIsStarted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -60,7 +60,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsActive() {
+    void testProcessInstanceIsActive() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -76,7 +76,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsCompleted() {
+    void testProcessInstanceIsCompleted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -93,7 +93,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompleted() {
+    void testProcessInstanceIsNotCompleted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -109,7 +109,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsTerminated() {
+    void testProcessInstanceIsTerminated() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -127,7 +127,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminated() {
+    void testProcessInstanceIsNotTerminated() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -143,7 +143,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElement() {
+    void testProcessInstanceHasPassedElement() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -161,7 +161,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElement() {
+    void testProcessInstanceHasNotPassedElement() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -178,7 +178,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementMultipleTimes() {
+    void testProcessInstanceHasPassedElementMultipleTimes() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final int totalLoops = 5;
@@ -199,7 +199,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementsInOrder() {
+    void testProcessInstanceHasPassedElementsInOrder() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -220,7 +220,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAt() {
+    void testProcessInstanceIsWaitingAt() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -234,7 +234,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessIsWaitingAtMultipleElements() {
+    void testProcessIsWaitingAtMultipleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -251,7 +251,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAt() {
+    void testProcessInstanceIsNotWaitingAt() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -266,7 +266,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMultipleElements() {
+    void testProcessInstanceIsNotWaitingAtMultipleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -286,7 +286,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtNonExistingElement() {
+    void testProcessInstanceIsNotWaitingAtNonExistingElement() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -300,7 +300,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElements() {
+    void testProcessInstanceIsWaitingExactlyAtElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -316,7 +316,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessage() {
+    void testProcessInstanceIsWaitingForMessage() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -333,7 +333,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessage() {
+    void testProcessInstanceIsNotWaitingForMessage() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -353,7 +353,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariable() {
+    void testProcessInstanceHasVariable() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -369,7 +369,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValue() {
+    void testProcessInstanceHasVariableWithValue() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -388,7 +388,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByName() {
+    void testHasCorrelatedMessageByName() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -407,7 +407,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKey() {
+    void testHasCorrelatedMessageByCorrelationKey() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -426,7 +426,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasAnyIncidents() {
+    void testHasAnyIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -446,7 +446,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidents() {
+    void testHasNoIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -459,7 +459,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testExtractLatestIncident() {
+    void testExtractLatestIncident() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -495,7 +495,7 @@ class ProcessInstanceAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testProcessInstanceIsStartedFailure() {
+    void testProcessInstanceIsStartedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent mockInstanceEvent = mock(ProcessInstanceEvent.class);
@@ -511,7 +511,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch() {
+    void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
@@ -527,7 +527,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsActiveFailure() {
+    void testProcessInstanceIsActiveFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -547,7 +547,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsCompletedFailure() {
+    void testProcessInstanceIsCompletedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -567,7 +567,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompletedFailure() {
+    void testProcessInstanceIsNotCompletedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -587,7 +587,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsTerminatedFailure() {
+    void testProcessInstanceIsTerminatedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -607,7 +607,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminatedFailure() {
+    void testProcessInstanceIsNotTerminatedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -628,7 +628,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementFailure() {
+    void testProcessInstanceHasPassedElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -652,7 +652,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElementFailure() {
+    void testProcessInstanceHasNotPassedElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -677,7 +677,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementsInOrderFailure() {
+    void testProcessInstanceHasPassedElementsInOrderFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -707,7 +707,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtFailure() {
+    void testProcessInstanceIsWaitingAtFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -726,7 +726,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtMultipleElementsFailure() {
+    void testProcessInstanceIsWaitingAtMultipleElementsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -754,7 +754,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceWaitingAtNonExistingElementFailure() {
+    void testProcessInstanceWaitingAtNonExistingElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -771,7 +771,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtFailure() {
+    void testProcessInstanceIsNotWaitingAtFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -789,7 +789,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure() {
+    void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -814,7 +814,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -838,7 +838,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -867,7 +867,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -898,7 +898,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessageFailure() {
+    void testProcessInstanceIsWaitingForMessageFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -921,7 +921,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessageFailure() {
+    void testProcessInstanceIsNotWaitingForMessageFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -943,7 +943,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableFailure() {
+    void testProcessInstanceHasVariableFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String expectedVariable = "variable";
@@ -962,7 +962,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValueFailure() {
+    void testProcessInstanceHasVariableWithValueFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String variable = "variable";
@@ -989,7 +989,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByNameFailure() {
+    void testHasCorrelatedMessageByNameFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -1013,7 +1013,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKeyFailure() {
+    void testHasCorrelatedMessageByCorrelationKeyFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -1038,7 +1038,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasAnyIncidentsFailure() {
+    void testHasAnyIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -1053,7 +1053,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidentsFailure() {
+    void testHasNoIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -1074,7 +1074,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testExtractLatestIncidentFailure() {
+    void testExtractLatestIncidentFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/inspections/ProcessEventInspectionsTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/inspections/ProcessEventInspectionsTest.java
@@ -23,7 +23,7 @@ class ProcessEventInspectionsTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testFindFirstProcessInstance() {
+  void testFindFirstProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
@@ -43,7 +43,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindLastProcessInstance() {
+  void testFindLastProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
@@ -63,7 +63,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindFirstProcessInstance_wrongTimer() {
+  void testFindFirstProcessInstance_wrongTimer() {
     // given
     Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
@@ -79,7 +79,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindProcessInstance_highIndex() {
+  void testFindProcessInstance_highIndex() {
     // given
     Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/inspections/ProcessInstanceInspectionsTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/inspections/ProcessInstanceInspectionsTest.java
@@ -20,7 +20,7 @@ public class ProcessInstanceInspectionsTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testStartedByProcessInstanceWithProcessId() {
+  void testStartedByProcessInstanceWithProcessId() {
     // given
     Utilities.deployProcesses(
         client,
@@ -45,7 +45,7 @@ public class ProcessInstanceInspectionsTest {
   }
 
   @Test
-  public void testStartedByProcessInstanceWithProcessId_wrongId() {
+  void testStartedByProcessInstanceWithProcessId_wrongId() {
     // given
     Utilities.deployProcesses(
         client,

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/multithread/MultiThreadTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/multithread/MultiThreadTest.java
@@ -33,17 +33,17 @@ public class MultiThreadTest {
   private ExecutorService executorService;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     executorService = Executors.newFixedThreadPool(5);
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     executorService.shutdown();
   }
 
   @Test
-  public void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
+  void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
     final List<Future<Boolean>> futures =
         executorService.invokeAll(
             Arrays.asList(

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/multithread/WorkerTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/multithread/WorkerTest.java
@@ -18,7 +18,7 @@ public class WorkerTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testJobsCanBeProcessedAsynchronouslyByWorker() throws InterruptedException {
+  void testJobsCanBeProcessedAsynchronouslyByWorker() throws InterruptedException {
     // given
     client
         .newWorker()

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/DeploymentAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/DeploymentAssertTest.java
@@ -26,7 +26,7 @@ class DeploymentAssertTest {
     private ZeebeClient client;
 
     @Test
-    public void testContainsProcessesById() {
+    void testContainsProcessesById() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcesses(
@@ -41,7 +41,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testContainsProcessesByResourceName() {
+    void testContainsProcessesByResourceName() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcesses(
@@ -56,7 +56,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByBpmnProcessId() {
+    void testExtractingProcessByBpmnProcessId() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -71,7 +71,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByResourceName() {
+    void testExtractingProcessByResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -93,7 +93,7 @@ class DeploymentAssertTest {
     private ZeebeClient client;
 
     @Test
-    public void testContainsProcessesByIdFailure() {
+    void testContainsProcessesByIdFailure() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -108,7 +108,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testContainsProcessesByResourceNameFailure() {
+    void testContainsProcessesByResourceNameFailure() {
       // when
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -123,7 +123,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByBpmnProcessIdFailure() {
+    void testExtractingProcessByBpmnProcessIdFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -139,7 +139,7 @@ class DeploymentAssertTest {
     }
 
     @Test
-    public void testExtractingProcessByResourceName() {
+    void testExtractingProcessByResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessAssertTest.java
@@ -26,7 +26,7 @@ class ProcessAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testHasBPMNProcessId() {
+    void testHasBPMNProcessId() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -41,7 +41,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasVersion() {
+    void testHasVersion() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -56,7 +56,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasResourceName() {
+    void testHasResourceName() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -71,7 +71,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasAnyInstances() {
+    void testHasAnyInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -88,7 +88,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasNoInstances() {
+    void testHasNoInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -103,7 +103,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() {
+    void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -129,7 +129,7 @@ class ProcessAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testHasBPMNProcessIdFailure() {
+    void testHasBPMNProcessIdFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -148,7 +148,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasVersionFailure() {
+    void testHasVersionFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -165,7 +165,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasResourceNameFailure() {
+    void testHasResourceNameFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -184,7 +184,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasAnyInstancesFailure() {
+    void testHasAnyInstancesFailure() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -201,7 +201,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasNoInstances() {
+    void testHasNoInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
@@ -220,7 +220,7 @@ class ProcessAssertTest {
     }
 
     @Test
-    public void testHasInstances() {
+    void testHasInstances() {
       // given
       final DeploymentEvent deploymentEvent =
           Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessInstanceAssertTest.java
@@ -44,7 +44,7 @@ class ProcessInstanceAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testProcessInstanceIsStarted() {
+    void testProcessInstanceIsStarted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -60,7 +60,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsActive() {
+    void testProcessInstanceIsActive() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -76,7 +76,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsCompleted() {
+    void testProcessInstanceIsCompleted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -93,7 +93,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompleted() {
+    void testProcessInstanceIsNotCompleted() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -109,7 +109,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsTerminated() {
+    void testProcessInstanceIsTerminated() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -127,7 +127,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminated() {
+    void testProcessInstanceIsNotTerminated() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -143,7 +143,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElement() {
+    void testProcessInstanceHasPassedElement() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -161,7 +161,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElement() {
+    void testProcessInstanceHasNotPassedElement() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -178,7 +178,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementMultipleTimes() {
+    void testProcessInstanceHasPassedElementMultipleTimes() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final int totalLoops = 5;
@@ -199,7 +199,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementsInOrder() {
+    void testProcessInstanceHasPassedElementsInOrder() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -220,7 +220,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAt() {
+    void testProcessInstanceIsWaitingAt() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -234,7 +234,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessIsWaitingAtMultipleElements() {
+    void testProcessIsWaitingAtMultipleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -251,7 +251,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAt() {
+    void testProcessInstanceIsNotWaitingAt() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -266,7 +266,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMultipleElements() {
+    void testProcessInstanceIsNotWaitingAtMultipleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -286,7 +286,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtNonExistingElement() {
+    void testProcessInstanceIsNotWaitingAtNonExistingElement() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -300,7 +300,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElements() {
+    void testProcessInstanceIsWaitingExactlyAtElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -316,7 +316,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessage() {
+    void testProcessInstanceIsWaitingForMessage() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -333,7 +333,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessage() {
+    void testProcessInstanceIsNotWaitingForMessage() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -353,7 +353,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariable() {
+    void testProcessInstanceHasVariable() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -369,7 +369,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValue() {
+    void testProcessInstanceHasVariableWithValue() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -388,7 +388,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByName() {
+    void testHasCorrelatedMessageByName() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -407,7 +407,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKey() {
+    void testHasCorrelatedMessageByCorrelationKey() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -426,7 +426,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasAnyIncidents() {
+    void testHasAnyIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -446,7 +446,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidents() {
+    void testHasNoIncidents() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -459,7 +459,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testExtractLatestIncident() {
+    void testExtractLatestIncident() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -495,7 +495,7 @@ class ProcessInstanceAssertTest {
     private InMemoryEngine engine;
 
     @Test
-    public void testProcessInstanceIsStartedFailure() {
+    void testProcessInstanceIsStartedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent mockInstanceEvent = mock(ProcessInstanceEvent.class);
@@ -511,7 +511,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch() {
+    void testProcessInstanceIsNotStartedIfProcessInstanceKeyNoMatch() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
@@ -527,7 +527,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsActiveFailure() {
+    void testProcessInstanceIsActiveFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -547,7 +547,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsCompletedFailure() {
+    void testProcessInstanceIsCompletedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -567,7 +567,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotCompletedFailure() {
+    void testProcessInstanceIsNotCompletedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -587,7 +587,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsTerminatedFailure() {
+    void testProcessInstanceIsTerminatedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -607,7 +607,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotTerminatedFailure() {
+    void testProcessInstanceIsNotTerminatedFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -628,7 +628,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementFailure() {
+    void testProcessInstanceHasPassedElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -652,7 +652,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasNotPassedElementFailure() {
+    void testProcessInstanceHasNotPassedElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -677,7 +677,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasPassedElementsInOrderFailure() {
+    void testProcessInstanceHasPassedElementsInOrderFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -707,7 +707,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtFailure() {
+    void testProcessInstanceIsWaitingAtFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -726,7 +726,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingAtMultipleElementsFailure() {
+    void testProcessInstanceIsWaitingAtMultipleElementsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
       final ProcessInstanceEvent instanceEvent =
@@ -754,7 +754,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceWaitingAtNonExistingElementFailure() {
+    void testProcessInstanceWaitingAtNonExistingElementFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -771,7 +771,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtFailure() {
+    void testProcessInstanceIsNotWaitingAtFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -789,7 +789,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure() {
+    void testProcessInstanceIsNotWaitingAtMulitpleElementsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -814,7 +814,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooManyElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -838,7 +838,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_tooLittleElements() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -867,7 +867,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination() {
+    void testProcessInstanceIsWaitingExactlyAtElementsFailure_combination() {
       // given
       Utilities.deployProcess(client, ProcessPackMultipleTasks.RESOURCE_NAME);
 
@@ -898,7 +898,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsWaitingForMessageFailure() {
+    void testProcessInstanceIsWaitingForMessageFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -921,7 +921,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceIsNotWaitingForMessageFailure() {
+    void testProcessInstanceIsNotWaitingForMessageFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -943,7 +943,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableFailure() {
+    void testProcessInstanceHasVariableFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String expectedVariable = "variable";
@@ -962,7 +962,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testProcessInstanceHasVariableWithValueFailure() {
+    void testProcessInstanceHasVariableWithValueFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final String variable = "variable";
@@ -989,7 +989,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByNameFailure() {
+    void testHasCorrelatedMessageByNameFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -1013,7 +1013,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasCorrelatedMessageByCorrelationKeyFailure() {
+    void testHasCorrelatedMessageByCorrelationKeyFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackMessageEvent.RESOURCE_NAME);
       final String correlationKey = "key";
@@ -1038,7 +1038,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasAnyIncidentsFailure() {
+    void testHasAnyIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 
@@ -1053,7 +1053,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testHasNoIncidentsFailure() {
+    void testHasNoIncidentsFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
       final Map<String, Object> variables =
@@ -1074,7 +1074,7 @@ class ProcessInstanceAssertTest {
     }
 
     @Test
-    public void testExtractLatestIncidentFailure() {
+    void testExtractLatestIncidentFailure() {
       // given
       Utilities.deployProcess(client, ProcessPackLoopingServiceTask.RESOURCE_NAME);
 

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessEventInspectionsTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessEventInspectionsTest.java
@@ -23,7 +23,7 @@ class ProcessEventInspectionsTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testFindFirstProcessInstance() {
+  void testFindFirstProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
@@ -43,7 +43,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindLastProcessInstance() {
+  void testFindLastProcessInstance() {
     // given
     final DeploymentEvent deploymentEvent =
         Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
@@ -63,7 +63,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindFirstProcessInstance_wrongTimer() {
+  void testFindFirstProcessInstance_wrongTimer() {
     // given
     Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 
@@ -79,7 +79,7 @@ class ProcessEventInspectionsTest {
   }
 
   @Test
-  public void testFindProcessInstance_highIndex() {
+  void testFindProcessInstance_highIndex() {
     // given
     Utilities.deployProcess(client, ProcessPackTimerStartEvent.RESOURCE_NAME);
 

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInstanceInspectionsTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/inspections/ProcessInstanceInspectionsTest.java
@@ -20,7 +20,7 @@ public class ProcessInstanceInspectionsTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testStartedByProcessInstanceWithProcessId() {
+  void testStartedByProcessInstanceWithProcessId() {
     // given
     Utilities.deployProcesses(
         client,
@@ -45,7 +45,7 @@ public class ProcessInstanceInspectionsTest {
   }
 
   @Test
-  public void testStartedByProcessInstanceWithProcessId_wrongId() {
+  void testStartedByProcessInstanceWithProcessId_wrongId() {
     // given
     Utilities.deployProcesses(
         client,

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/MultiThreadTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/MultiThreadTest.java
@@ -33,17 +33,17 @@ public class MultiThreadTest {
   private ExecutorService executorService;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     executorService = Executors.newFixedThreadPool(5);
   }
 
   @AfterEach
-  public void afterEach() {
+  void afterEach() {
     executorService.shutdown();
   }
 
   @Test
-  public void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
+  void testMultiThreadingThrowsNoExceptions() throws InterruptedException {
     final List<Future<Boolean>> futures =
         executorService.invokeAll(
             Arrays.asList(

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/WorkerTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/multithread/WorkerTest.java
@@ -18,7 +18,7 @@ public class WorkerTest {
   private InMemoryEngine engine;
 
   @Test
-  public void testJobsCanBeProcessedAsynchronouslyByWorker() throws InterruptedException {
+  void testJobsCanBeProcessedAsynchronouslyByWorker() throws InterruptedException {
     // given
     client
         .newWorker()


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR removes the `public` keywords from our test methods.
jUnit5 supports tests methods without a public keyword. By convention we want methods to be scope as small as possible. We should also adhere to this in our test classes.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #197 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
