### PR TITLE
Remove runOnIdleState functionality

### DIFF
--- a/api/src/main/java/io/camunda/zeebe/process/test/api/InMemoryEngine.java
+++ b/api/src/main/java/io/camunda/zeebe/process/test/api/InMemoryEngine.java
@@ -30,15 +30,6 @@ public interface InMemoryEngine {
   void increaseTime(Duration timeToAdd);
 
   /**
-   * Runs the given function once the engine has reached an idle state.
-   *
-   * <p>For more info on the idle state refer to {@link IdleStateMonitor}
-   *
-   * @param callback the function that should be executed once an idle state has been reached
-   */
-  void runOnIdleState(Runnable callback);
-
-  /**
    * Waits for the engine to reach an idle state.
    *
    * <p>For more info on the idle state refer to {@link IdleStateMonitor}

--- a/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngineImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/process/test/engine/InMemoryEngineImpl.java
@@ -102,15 +102,10 @@ public class InMemoryEngineImpl implements InMemoryEngine {
   }
 
   @Override
-  public void runOnIdleState(final Runnable callback) {
-    idleStateMonitor.addCallback(callback);
-  }
-
-  @Override
   public void waitForIdleState() {
     final CompletableFuture<Void> idleState = new CompletableFuture<>();
 
-    runOnIdleState(() -> idleState.complete(null));
+    idleStateMonitor.addCallback(() -> idleState.complete(null));
 
     idleState.join();
   }

--- a/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
+++ b/extension-testcontainer/src/main/java/io.camunda.zeebe.process.test.extension.testcontainer/ContainerizedEngine.java
@@ -123,11 +123,6 @@ public class ContainerizedEngine implements InMemoryEngine {
   }
 
   @Override
-  public void runOnIdleState(final Runnable callback) {
-    // TODO remove this from interface?
-  }
-
-  @Override
   public void waitForIdleState() {
     final ManagedChannel channel = getChannel();
     final EngineControlBlockingStub stub = getStub(channel);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Run on idle state is a feature that we don't want to support at this time. It's best to keep the public interface as minimal as possible before the release. If it turns out users wish to use a functionality like these we can always re-add it later.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
