### PR TITLE
Release/1.4.0 alpha2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_call: { }
 jobs:
   code-formatting:
-    name: Apply code formatting
+    name: check code formatting
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
@@ -27,12 +27,7 @@ jobs:
           java-version: 17
 
       - name: Apply format
-        run: mvn spotless:apply
-
-      - name: Commit and push format changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore: apply format"
+        run: mvn spotless:check
 
   build-and-test:
     name: Run tests on ${{ matrix.os }}

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -65,6 +65,9 @@ jobs:
           cd engine-agent
           mvn clean package -DskipTests
 
+        # We build a docker image with a specific tag. There are 2 possible scenarios here.
+        # 1. The workflow is triggered manually or by a change on the main branch. The tag should be 'latest'.
+        # 2. The workflow is triggered by a new release. The tag should be the version of the release.
       - name: Build Docker image
         run: |
           if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
@@ -73,6 +76,7 @@ jobs:
           cd engine-agent
           docker build . -t $IMAGE_NAME:$TAG
 
+        # We push the docker image to dockerhub
       - name: Push Docker image
         run: |
           if ! [ -z "${{ github.event.release.tag_name }}" ] && ! grep -q "$TAG" <<< "SNAPSHOT"; then
@@ -86,9 +90,15 @@ jobs:
           docker tag $IMAGE_NAME:$TAG $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
+        # In extension-testcontainer we have a config file which contains the image tag. This is managed by maven and
+        # maven will set this to the project version upon packaging the application (e.g. 1.4.0, 1.4.0-alpha1, etc.).
+        # In the case this workflow is triggered by a change on the main branch we want this tag to be set to latest.
+        # Maven would set it to a SNAPSHOT version in this case. Therefore, we need to manually set this tag to latest
+        # in this step. This replaces the other value (${project.version}), so it doesn't get replaced by maven anymore.
       - name: Update tag in config
         if: github.ref == 'refs/head/main'
         run: |
+          cd extension-testcontainer/src/main/resources
           sed -i '/container.image.tag=/ s:=.*:='$TAG':' config.properties
           cat config.properties
 
@@ -99,6 +109,10 @@ jobs:
           gpg_private_key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           passphrase: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
+        # In extension-testcontainer we have a config file which contains the image tag. This is managed by maven and
+        # maven will set this to the project version in this step, unless the placeholder (${project.version}) has been
+        # overridden by the "Update tag in config" step. This happens when the workflow is triggered by a change on the
+        # main branch.
       - name: Build and deploy to Maven
         id: release
         uses: camunda-community-hub/community-action-maven-release@v1.0.12

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -86,19 +86,6 @@ jobs:
           docker tag $IMAGE_NAME:$TAG $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
-      - name: Update image and tag in Git
-        run : |
-          git config --global user.name "Release Bot"
-          git config --global user.email actions@github.com
-          cd extension-testcontainer/src/main/resources
-          IMAGE_ID=$OWNER/$IMAGE_NAME
-          sed -i '/container.image.name=/ s:=.*:='$IMAGE_ID':' config.properties
-          sed -i '/container.image.tag=/ s:=.*:='$TAG':' config.properties
-          if [[ `git status --porcelain --untracked-files=no` ]] && [[ `git symbolic-ref -q HEAD` ]]; then
-            git commit -am "(release): update image and tag ($IMAGE_ID:$TAG)"
-            git push
-          fi
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -86,6 +86,12 @@ jobs:
           docker tag $IMAGE_NAME:$TAG $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
+      - name: Update tag in config
+        if: github.ref == 'refs/head/main'
+        run: |
+          sed -i '/container.image.tag=/ s:=.*:='$TAG':' config.properties
+          cat config.properties
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/.github/workflows/deploy-artifact.yml
+++ b/.github/workflows/deploy-artifact.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     uses: ./.github/workflows/build-test.yml
 
-  deploy-to-docker:
+  deploy:
     runs-on: ubuntu-latest
     needs: [test]
 
@@ -47,6 +47,12 @@ jobs:
           secrets: |
             secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_USR;
+            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_PSW;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
 
       - name: Set up Java environment
         uses: actions/setup-java@v3.0.0
@@ -92,43 +98,6 @@ jobs:
             git commit -am "(release): update image and tag ($IMAGE_ID:$TAG)"
             git push
           fi
-
-  deploy-to-maven:
-    runs-on: ubuntu-latest
-    needs: [deploy-to-docker]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_USR;
-            secret/data/common/github.com/actions/camunda-cloud/zeebe-process-test ARTIFACTS_PSW;
-            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_USR;
-            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_DEPLOYMENT_PSW;
-            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
-            secret/data/common/github.com/actions/camunda-community-hub MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
-
-      - name: Set up Java environment
-        uses: actions/setup-java@v3.0.0
-        with:
-          distribution: temurin
-          java-version: 17
 
       - name: Import GPG key
         id: import_gpg

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -64,4 +64,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
 </project>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -67,8 +67,8 @@
   <build>
     <resources>
       <resource>
-        <directory>src/main/resources</directory>
         <filtering>true</filtering>
+        <directory>src/main/resources</directory>
       </resource>
     </resources>
   </build>

--- a/extension-testcontainer/src/main/resources/config.properties
+++ b/extension-testcontainer/src/main/resources/config.properties
@@ -1,7 +1,7 @@
 # The image name of the containerized engine
 container.image.name=camunda/zeebe-process-test-engine
 # The tag of the image
-container.image.tag=latest
+container.image.tag=${project.version}
 # The port at which the in memory engine gateway is listening
 container.gateway.port=26500
 # The port at which the engine controller is listening


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Several fixes in the workflow to deal with the fact that git is in headless mode when checking out a release tag.

1. The deploy to maven and the deploy to docker jobs have been combined into a single deploy job
2. Maven is now used to set the image tag in `extension-testcontainer` config file.
3. A new step had been introduces to make sure changes on the `main` branch are still using the `latest` tag. This way we keep the same behaviour as we had previously.



<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
