### PR TITLE
Cleanup compile time dependencies

### DIFF
--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -43,16 +43,6 @@
       <artifactId>assertj-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
-    </dependency>
-
     <!-- Test scope-->
     <dependency>
       <groupId>org.mockito</groupId>
@@ -69,6 +59,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -53,11 +53,6 @@
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-    </dependency>
-
     <!-- Test scope-->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/assertions/pom.xml
+++ b/assertions/pom.xml
@@ -66,6 +66,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -28,6 +28,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-process-test-engine-protocol</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Test Scope -->
@@ -81,6 +81,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -41,11 +41,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
 
@@ -64,6 +59,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/extension-testcontainer/pom.xml
+++ b/extension-testcontainer/pom.xml
@@ -62,6 +62,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- Test scope  -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -39,8 +39,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test scope-->
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -33,9 +33,10 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- Test scope-->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
@@ -45,6 +46,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <properties>
     <dependency.assertj.version>3.22.0</dependency.assertj.version>
     <dependency.awaitility.version>4.1.1</dependency.awaitility.version>
+    <dependency.commons.version>3.12.0</dependency.commons.version>
     <dependency.errorprone.version>2.11.0</dependency.errorprone.version>
     <dependency.eze.version>0.6.0</dependency.eze.version>
     <dependency.feel.version>1.14.2</dependency.feel.version>
@@ -306,6 +307,12 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${dependency.awaitility.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${dependency.commons.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@
 
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${dependency.slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>${dependency.slf4j.version}</version>
       </dependency>
@@ -271,11 +277,6 @@
         <version>${dependency.spring.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${dependency.slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
     <dependency.jna.version>5.10.0</dependency.jna.version>
     <dependency.junit.version>5.8.2</dependency.junit.version>
     <dependency.junit4.version>4.13.2</dependency.junit4.version>
-    <dependency.log4j.version>2.17.1</dependency.log4j.version>
     <dependency.mockito.version>4.3.1</dependency.mockito.version>
     <dependency.netty.version>4.1.74.Final</dependency.netty.version>
     <dependency.osgi.version>6.0.0</dependency.osgi.version>
@@ -282,11 +281,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${dependency.snakeyaml.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${dependency.log4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.immutables</groupId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -46,6 +46,18 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -42,12 +42,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR gets rid of dependencies to any `slf4j` implementation. Instead we make use of the `slf4j-api`. In our tests we still need to provide an implementation which is done by adding `slf4j-simple` as a test scoped dependency. I got rid of `log4j` as `slf4j-simple` is more lightweight.

I've also gone through the other dependencies. As a result of the module split some of these were unused, or wrongly scoped. This PR also solves these issues.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #174 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
