### PR TITLE
Flaky test fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - name: Checkout

--- a/engine-agent/pom.xml
+++ b/engine-agent/pom.xml
@@ -34,6 +34,15 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!--  Usually we don't want to provide an slf4j implementation in this project. This module
+      is the only exception to this rule. This is because we need to provide the engine with an
+      implementation, and since this runs in a docker container the user won't be providing it. -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
@@ -79,6 +88,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+          <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/RecordStreamSourceWrapper.java
+++ b/engine-agent/src/main/java/io/camunda/zeebe/process/test/engine/agent/RecordStreamSourceWrapper.java
@@ -2,12 +2,15 @@ package io.camunda.zeebe.process.test.engine.agent;
 
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 public class RecordStreamSourceWrapper {
 
   private final List<String> mappedRecords = new ArrayList<>();
   private final RecordStreamSource recordStreamSource;
+  private volatile long lastEventPosition = -1L;
 
   public RecordStreamSourceWrapper(final RecordStreamSource recordStreamSource) {
     this.recordStreamSource = recordStreamSource;
@@ -15,9 +18,15 @@ public class RecordStreamSourceWrapper {
 
   public List<String> getMappedRecords() {
     synchronized (mappedRecords) {
-      mappedRecords.clear();
-      recordStreamSource.records().forEach(record -> mappedRecords.add(record.toJson()));
+      StreamSupport.stream(recordStreamSource.records().spliterator(), false)
+          .filter(record -> record.getPosition() > lastEventPosition)
+          .forEach(
+              record -> {
+                mappedRecords.add(record.toJson());
+                lastEventPosition = record.getPosition();
+              });
     }
-    return new ArrayList<>(mappedRecords);
+
+    return Collections.unmodifiableList(mappedRecords);
   }
 }

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/util/Utilities.java
@@ -21,58 +21,6 @@ import java.util.stream.Collectors;
 
 public class Utilities {
 
-  public static final class ProcessPackLoopingServiceTask {
-    public static final String RESOURCE_NAME = "looping-servicetask.bpmn";
-    public static final String PROCESS_ID = "looping-servicetask";
-
-    public static final String ELEMENT_ID = "servicetask"; // id of the service task
-    public static final String JOB_TYPE = "test"; // job type of service task
-    public static final String TOTAL_LOOPS =
-        "totalLoops"; // variable name to indicate number of loops
-    public static final String GATEWAY_ELEMENT_ID = "Gateway_0fhwf5d";
-    public static final String START_EVENT_ID = "startevent";
-    public static final String END_EVENT_ID = "endevent";
-  }
-
-  public static final class ProcessPackMultipleTasks {
-    public static final String RESOURCE_NAME = "multiple-tasks.bpmn";
-    public static final String PROCESS_ID = "multiple-tasks";
-    public static final String ELEMENT_ID_1 = "servicetask1";
-    public static final String ELEMENT_ID_2 = "servicetask2";
-    public static final String ELEMENT_ID_3 = "servicetask3";
-  }
-
-  public static final class ProcessPackMessageEvent {
-    public static final String RESOURCE_NAME = "message-event.bpmn";
-    public static final String PROCESS_ID = "message-event";
-    public static final String MESSAGE_NAME = "message";
-    public static final String CORRELATION_KEY_VARIABLE = "correlationKey";
-  }
-
-  public static final class ProcessPackMessageStartEvent {
-    public static final String RESOURCE_NAME = "message-start-event.bpmn";
-    public static final String MESSAGE_NAME = "start-message";
-    public static final String CORRELATION_KEY = "";
-  }
-
-  public static final class ProcessPackTimerStartEvent {
-    public static final String RESOURCE_NAME = "timer-start-event-daily.bpmn";
-    public static final String TIMER_ID = "timer";
-  }
-
-  public static final class ProcessPackCallActivity {
-    public static final String RESOURCE_NAME = "call-activity.bpmn";
-    public static final String PROCESS_ID = "call-activity";
-    public static final String CALL_ACTIVITY_ID = "callactivity";
-    public static final String CALLED_RESOURCE_NAME = ProcessPackStartEndEvent.RESOURCE_NAME;
-    public static final String CALLED_PROCESS_ID = ProcessPackStartEndEvent.PROCESS_ID;
-  }
-
-  public static final class ProcessPackStartEndEvent {
-    public static final String RESOURCE_NAME = "start-end.bpmn";
-    public static final String PROCESS_ID = "start-end";
-  }
-
   public static DeploymentEvent deployProcess(final ZeebeClient client, final String process) {
     return deployProcesses(client, process);
   }
@@ -162,12 +110,13 @@ public class Utilities {
 
   public static void increaseTime(final InMemoryEngine engine, final Duration duration)
       throws InterruptedException {
-    engine.increaseTime(duration);
     try {
-      waitForBusyState(engine, Duration.ofSeconds(5));
       waitForIdleState(engine, Duration.ofSeconds(1));
-    } catch (TimeoutException e) {
-      // Do nothing. We've waited up to 250 ms for processing to start, if it didn't start in this
+      engine.increaseTime(duration);
+      waitForBusyState(engine, Duration.ofSeconds(1));
+      waitForIdleState(engine, Duration.ofSeconds(1));
+    } catch (final TimeoutException e) {
+      // Do nothing. We've waited up to 1 second for processing to start, if it didn't start in this
       // time the engine probably has not got anything left to process.
     }
   }
@@ -203,5 +152,64 @@ public class Utilities {
       throws InterruptedException, TimeoutException {
     client.newThrowErrorCommand(key).errorCode(errorCode).errorMessage(errorMessage).send().join();
     waitForIdleState(engine, Duration.ofSeconds(1));
+  }
+
+  public static final class ProcessPackLoopingServiceTask {
+
+    public static final String RESOURCE_NAME = "looping-servicetask.bpmn";
+    public static final String PROCESS_ID = "looping-servicetask";
+
+    public static final String ELEMENT_ID = "servicetask"; // id of the service task
+    public static final String JOB_TYPE = "test"; // job type of service task
+    public static final String TOTAL_LOOPS =
+        "totalLoops"; // variable name to indicate number of loops
+    public static final String GATEWAY_ELEMENT_ID = "Gateway_0fhwf5d";
+    public static final String START_EVENT_ID = "startevent";
+    public static final String END_EVENT_ID = "endevent";
+  }
+
+  public static final class ProcessPackMultipleTasks {
+
+    public static final String RESOURCE_NAME = "multiple-tasks.bpmn";
+    public static final String PROCESS_ID = "multiple-tasks";
+    public static final String ELEMENT_ID_1 = "servicetask1";
+    public static final String ELEMENT_ID_2 = "servicetask2";
+    public static final String ELEMENT_ID_3 = "servicetask3";
+  }
+
+  public static final class ProcessPackMessageEvent {
+
+    public static final String RESOURCE_NAME = "message-event.bpmn";
+    public static final String PROCESS_ID = "message-event";
+    public static final String MESSAGE_NAME = "message";
+    public static final String CORRELATION_KEY_VARIABLE = "correlationKey";
+  }
+
+  public static final class ProcessPackMessageStartEvent {
+
+    public static final String RESOURCE_NAME = "message-start-event.bpmn";
+    public static final String MESSAGE_NAME = "start-message";
+    public static final String CORRELATION_KEY = "";
+  }
+
+  public static final class ProcessPackTimerStartEvent {
+
+    public static final String RESOURCE_NAME = "timer-start-event-daily.bpmn";
+    public static final String TIMER_ID = "timer";
+  }
+
+  public static final class ProcessPackCallActivity {
+
+    public static final String RESOURCE_NAME = "call-activity.bpmn";
+    public static final String PROCESS_ID = "call-activity";
+    public static final String CALL_ACTIVITY_ID = "callactivity";
+    public static final String CALLED_RESOURCE_NAME = ProcessPackStartEndEvent.RESOURCE_NAME;
+    public static final String CALLED_PROCESS_ID = ProcessPackStartEndEvent.PROCESS_ID;
+  }
+
+  public static final class ProcessPackStartEndEvent {
+
+    public static final String RESOURCE_NAME = "start-end.bpmn";
+    public static final String PROCESS_ID = "start-end";
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

### testLastProcessInstance

This test was flaky because we immediately increased the engine time after doing the deployment. This could result in the engine time being increased, before the timer is scheduled.
That means if the timer is expected to be scheduled in 1 day. It would now be scheduled in 1 day + the increase in engine time. This caused the timer to not be triggered at all.

### MultiThreadTest

I also encountered a different flaky test which is also fixed by this pr. This is the `MutltiThreadTest`.
This test was only flaky when running it using testcontainers. The problem lies in the `RecordStreamSourceWrapper`. In this class we would get all the records from the engine (`RecordStreamSource`). These records would be mapped to json and put into a list. The problem for this test was that we just override all records everytime we request them from the engine.

With this change we keep track of the latest event we've mapped. When we get a new request we will fetch all the records of the engine. We will filter those so we only have the records that we haven't stored in our list yet. These will be mapped and added. When the mapping is done we return a copy of the list. We need to make sure no more records are added, because the calling method will iterate over this list.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #202

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
