### PR TITLE
Rename extract methods to extracting

### DIFF
--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/IncidentAssert.java
@@ -18,6 +18,7 @@ import org.assertj.core.api.StringAssert;
 
 /** Assertions for incidents. An incident is identified by its incident key. */
 public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
+
   private final String LINE_SEPARATOR = System.lineSeparator();
 
   private final RecordStream recordStream;
@@ -80,7 +81,7 @@ public class IncidentAssert extends AbstractAssert<IncidentAssert, Long> {
    *
    * @return {@link StringAssert} of error message
    */
-  public StringAssert extractErrorMessage() {
+  public StringAssert extractingErrorMessage() {
     final IncidentRecordValue record = getIncidentCreatedRecordValue();
     final String actualErrorMessage = record.getErrorMessage();
 

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/JobAssert.java
@@ -127,7 +127,7 @@ public class JobAssert extends AbstractAssert<JobAssert, ActivatedJob> {
    *
    * @return {@link IncidentAssert} for the latest incident
    */
-  public IncidentAssert extractLatestIncident() {
+  public IncidentAssert extractingLatestIncident() {
     hasAnyIncidents();
 
     final List<Record<IncidentRecordValue>> incidentCreatedRecords =

--- a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
+++ b/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java
@@ -15,7 +15,12 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.SoftAssertions;
@@ -559,7 +564,7 @@ public class ProcessInstanceAssert extends AbstractAssert<ProcessInstanceAssert,
    *
    * @return {@link IncidentAssert} for the latest incident
    */
-  public IncidentAssert extractLatestIncident() {
+  public IncidentAssert extractingLatestIncident() {
     hasAnyIncidents();
 
     final List<Record<IncidentRecordValue>> incidentCreatedRecords =

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/IncidentAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/IncidentAssertTest.java
@@ -49,7 +49,8 @@ class IncidentAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT);
@@ -68,7 +69,8 @@ class IncidentAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.hasErrorMessage(
@@ -89,9 +91,10 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
-      final StringAssert messageAssert = incidentAssert.extractErrorMessage();
+      final StringAssert messageAssert = incidentAssert.extractingErrorMessage();
 
       // then
       Assertions.assertThat(messageAssert).isNotNull();
@@ -114,7 +117,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.wasRaisedInProcessInstance(processInstanceEvent);
@@ -143,7 +147,7 @@ class IncidentAssertTest {
       Utilities.waitForIdleState(engine, Duration.ofSeconds(1));
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
       incidentAssert.occurredOnElement(ProcessPackLoopingServiceTask.GATEWAY_ELEMENT_ID);
@@ -162,7 +166,7 @@ class IncidentAssertTest {
       final ActivatedJob job = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, job.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractLatestIncident();
+      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractingLatestIncident();
 
       // then
       incidentAssert.occurredDuringJob(job);
@@ -183,7 +187,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       final long incidentKey = incidentAssert.getIncidentKey();
       client.newResolveIncidentCommand(incidentKey).send().join();
@@ -208,7 +213,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.isUnresolved();
@@ -236,7 +242,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.hasErrorType(ErrorType.IO_MAPPING_ERROR))
@@ -259,7 +266,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.hasErrorMessage(WRONG_VALUE))
@@ -283,7 +291,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.wasRaisedInProcessInstance(-1))
@@ -315,7 +324,7 @@ class IncidentAssertTest {
       Utilities.waitForIdleState(engine, Duration.ofSeconds(1));
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.occurredOnElement(WRONG_VALUE))
@@ -338,7 +347,7 @@ class IncidentAssertTest {
       final ActivatedJob job = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, job.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractLatestIncident();
+      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.occurredDuringJob(-1))
@@ -362,7 +371,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(incidentAssert::isResolved)
@@ -384,7 +394,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       final long incidentKey = incidentAssert.getIncidentKey();
       client.newResolveIncidentCommand(incidentKey).send().join();

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/JobAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/JobAssertTest.java
@@ -161,7 +161,8 @@ class JobAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MSG);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       Assertions.assertThat(incidentAssert).isNotNull();
@@ -360,7 +361,7 @@ class JobAssertTest {
 
       // then
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
-      assertThatThrownBy(() -> BpmnAssert.assertThat(actual).extractLatestIncident())
+      assertThatThrownBy(() -> BpmnAssert.assertThat(actual).extractingLatestIncident())
           .isInstanceOf(AssertionError.class)
           .hasMessage("No incidents were raised for this job");
     }

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/regular/assertions/ProcessInstanceAssertTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 @ZeebeProcessTest
 class ProcessInstanceAssertTest {
+
   private static final String LINE_SEPARATOR = System.lineSeparator();
   private static final Map<String, Object> TYPED_TEST_VARIABLES = new HashMap<>();
 
@@ -482,7 +483,7 @@ class ProcessInstanceAssertTest {
       Utilities.completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
 
@@ -1104,7 +1105,7 @@ class ProcessInstanceAssertTest {
           Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
-      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).extractLatestIncident())
+      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).extractingLatestIncident())
           .isInstanceOf(AssertionError.class)
           .hasMessage("No incidents were raised for this process instance");
     }

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/IncidentAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/IncidentAssertTest.java
@@ -49,7 +49,8 @@ class IncidentAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT);
@@ -68,7 +69,8 @@ class IncidentAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.hasErrorMessage(
@@ -89,9 +91,10 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
-      final StringAssert messageAssert = incidentAssert.extractErrorMessage();
+      final StringAssert messageAssert = incidentAssert.extractingErrorMessage();
 
       // then
       Assertions.assertThat(messageAssert).isNotNull();
@@ -114,7 +117,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.wasRaisedInProcessInstance(processInstanceEvent);
@@ -143,7 +147,7 @@ class IncidentAssertTest {
       Utilities.waitForIdleState(engine, Duration.ofSeconds(1));
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
       incidentAssert.occurredOnElement(ProcessPackLoopingServiceTask.GATEWAY_ELEMENT_ID);
@@ -162,7 +166,7 @@ class IncidentAssertTest {
       final ActivatedJob job = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, job.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractLatestIncident();
+      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractingLatestIncident();
 
       // then
       incidentAssert.occurredDuringJob(job);
@@ -183,7 +187,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       final long incidentKey = incidentAssert.getIncidentKey();
       client.newResolveIncidentCommand(incidentKey).send().join();
@@ -208,7 +213,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       incidentAssert.isUnresolved();
@@ -236,7 +242,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.hasErrorType(ErrorType.IO_MAPPING_ERROR))
@@ -259,7 +266,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.hasErrorMessage(WRONG_VALUE))
@@ -283,7 +291,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.wasRaisedInProcessInstance(-1))
@@ -315,7 +324,7 @@ class IncidentAssertTest {
       Utilities.waitForIdleState(engine, Duration.ofSeconds(1));
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.occurredOnElement(WRONG_VALUE))
@@ -338,7 +347,7 @@ class IncidentAssertTest {
       final ActivatedJob job = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, job.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractLatestIncident();
+      final IncidentAssert incidentAssert = BpmnAssert.assertThat(job).extractingLatestIncident();
 
       // then
       assertThatThrownBy(() -> incidentAssert.occurredDuringJob(-1))
@@ -362,7 +371,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       assertThatThrownBy(incidentAssert::isResolved)
@@ -384,7 +394,8 @@ class IncidentAssertTest {
 
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MESSAGE);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       final long incidentKey = incidentAssert.getIncidentKey();
       client.newResolveIncidentCommand(incidentKey).send().join();

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/JobAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/JobAssertTest.java
@@ -161,7 +161,8 @@ class JobAssertTest {
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
       Utilities.throwErrorCommand(engine, client, actual.getKey(), ERROR_CODE, ERROR_MSG);
 
-      final IncidentAssert incidentAssert = BpmnAssert.assertThat(actual).extractLatestIncident();
+      final IncidentAssert incidentAssert =
+          BpmnAssert.assertThat(actual).extractingLatestIncident();
 
       // then
       Assertions.assertThat(incidentAssert).isNotNull();
@@ -360,7 +361,7 @@ class JobAssertTest {
 
       // then
       final ActivatedJob actual = jobActivationResponse.getJobs().get(0);
-      assertThatThrownBy(() -> BpmnAssert.assertThat(actual).extractLatestIncident())
+      assertThatThrownBy(() -> BpmnAssert.assertThat(actual).extractingLatestIncident())
           .isInstanceOf(AssertionError.class)
           .hasMessage("No incidents were raised for this job");
     }

--- a/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessInstanceAssertTest.java
+++ b/qa/src/test/java/io/camunda/zeebe/process/test/qa/testcontainer/assertions/ProcessInstanceAssertTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 @ZeebeProcessTest
 class ProcessInstanceAssertTest {
+
   private static final String LINE_SEPARATOR = System.lineSeparator();
   private static final Map<String, Object> TYPED_TEST_VARIABLES = new HashMap<>();
 
@@ -482,7 +483,7 @@ class ProcessInstanceAssertTest {
       Utilities.completeTask(engine, client, ProcessPackLoopingServiceTask.ELEMENT_ID);
 
       final IncidentAssert incidentAssert =
-          BpmnAssert.assertThat(instanceEvent).extractLatestIncident();
+          BpmnAssert.assertThat(instanceEvent).extractingLatestIncident();
 
       // then
 
@@ -1104,7 +1105,7 @@ class ProcessInstanceAssertTest {
           Utilities.startProcessInstance(engine, client, ProcessPackLoopingServiceTask.PROCESS_ID);
 
       // then
-      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).extractLatestIncident())
+      assertThatThrownBy(() -> BpmnAssert.assertThat(instanceEvent).extractingLatestIncident())
           .isInstanceOf(AssertionError.class)
           .hasMessage("No incidents were raised for this process instance");
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We should be consistent with the naming of our methods. At some places we used extractX, in other we used extractingX. They have all been changed to extractingX. This is consistent with the naming of AssertJ (e.g. assertThat(Map).extracting()).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually

Documentation:
* [ ] Javadoc has been written
* [ ] The documentation is updated
